### PR TITLE
docs: refresh execution reports for updated curriculum

### DIFF
--- a/reports/Day05.md
+++ b/reports/Day05.md
@@ -1,50 +1,44 @@
-# Day05 実行ログ
+# Day05 実行ログ（2026-01 更新）
 
-## 対象コード
-- 既存の `contracts/MyToken.sol`（固定Supply ERC-20）と Day11 で導入した `contracts/MyNFT.sol` を活用。
-- テストを新規追加：
-  - `test/erc20.ts` … `approve/allowance/transferFrom` の一連フロー。
-  - `test/mynft.ts` … baseURI 付きで mint し、`tokenURI` を検証。
-- スクリプトを整備：
-  - `scripts/deploy-token.ts`, `token-transfer.ts`, `token-approve.ts`
-  - `scripts/deploy-nft.ts`, `mint-nft.ts`
+## 確認したこと
+- ERC‑20（`MyToken`）の `transfer` / `approve` / `transferFrom` をスクリプトで実行できること。
+- ERC‑721（`MyNFT`）の mint と `tokenURI` を確認できること（`.../<id>.json` 形式）。
 
-## コマンドと結果
+## 実行（localhost）
+```bash
+npx hardhat node
 ```
-# 単体テスト（ERC20/NFT含む全体）
-npx hardhat test
-→ 9 passing (MyToken, MyNFT, WalletBox, Hello, GasBench)
 
-# ローカルネットでのデプロイ／操作例
+別ターミナルで：
+```bash
+# ERC-20 deploy
 npx hardhat run scripts/deploy-token.ts --network localhost
-→ MTK: 0x610178dA211FEF7D417bC0e6FeD39F05609AD788
 
-TOKEN=0x610178dA211FEF7D417bC0e6FeD39F05609AD788 \
+# transfer
+TOKEN=0x5FbDB2315678afecb367f032d93F642f64180aa3 \
   npx hardhat run scripts/token-transfer.ts --network localhost
-→ owner before: 1,000,000 MTK / bob after: 10 MTK
 
-TOKEN=... \
+# approve -> transferFrom（複数署名者を使う）
+TOKEN=0x5FbDB2315678afecb367f032d93F642f64180aa3 \
   npx hardhat run scripts/token-approve.ts --network localhost
-→ allowance: 1 MTK, transferFrom 完了
 
-NFT_BASE=ipfs://cid/ \
-  npx hardhat run scripts/deploy-nft.ts --network localhost
-→ MyNFT: 0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e
-
-NFT_ADDRESS=0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e \
+# ERC-721 deploy & mint
+npx hardhat run scripts/deploy-nft.ts --network localhost
+NFT_ADDRESS=0x5FC8d32690cc91D4c39d9d3abcBD16989F875707 \
   npx hardhat run scripts/mint-nft.ts --network localhost
-→ tokenURI: ipfs://cid/1
 ```
 
-## 追加確認
-- `token-transfer.ts` で `transfer` 後の `balanceOf` をログ表示。
-- `token-approve.ts` で `approve` → `allowance` → `transferFrom` を同一スクリプト内で実施。
-- `mint-nft.ts` の `tokenURI` 表示により baseURI + tokenId の結合結果を確認。
+### 結果（抜粋）
+- `MTK: 0x5FbDB2315678afecb367f032d93F642f64180aa3`
+- `token-transfer.ts`：
+  - `owner before: 1000000000000000000000000`
+  - `to: 0x70997970C51812dc3A010C7d01b50e0d17dc79C8`
+  - `to after: 10000000000000000000`
+- `token-approve.ts`：
+  - `allowance: 1000000000000000000`
+  - `transferFrom complete`
+- `MyNFT: 0x5FC8d32690cc91D4c39d9d3abcBD16989F875707`
+- `tokenURI: ipfs://example/1.json`
 
-## 未実施
-- Sepolia でのデプロイ／Etherscan確認は APIキー・秘密鍵を設定していないため未実行。`.env` に `SEPOLIA_RPC_URL`, `PRIVATE_KEY`, `ETHERSCAN_API_KEY` を入れた上で、同じコマンドを `--network sepolia` で再実行すれば再現可。
-
-## まとめ
-1. ERC-20/721 の典型操作（直接送金、approve/transferFrom、mint/tokenURI）をローカルRPCで自動化。
-2. ハンズオンで紹介されたスクリプトを TypeScript/ethers v6 形式で揃え、環境変数を切り替えるだけでテストネットへ流用可能。
-3. テストカバレッジに ERC-20 と NFT を加え、教材全体の自己診断をハードハットテスト1回で回せる状態に整備。
+## 未実施（外部依存）
+- Sepolia 等へのデプロイや Verify は、APIキー・秘密鍵が必要なため未実施。

--- a/reports/Day09.md
+++ b/reports/Day09.md
@@ -1,32 +1,26 @@
-# Day09 実行ログ
+# Day09 実行ログ（2026-01 更新）
 
-## フロントエンド構築
-- `dapp/` ディレクトリに React + Vite (+ TypeScript) プロジェクトを新規作成。
-- 主要ファイル：
-  - `package.json`（React18 + Vite + ethers + node-polyfills）
-  - `src/App.tsx`：ウォレット接続／ネットワーク切替／ETH・ERC20残高参照／トークン送信UI。
-  - `src/lib/web3.ts`：`ethers.BrowserProvider` を用いたユーティリティ。
-  - `vite.config.ts`, `tsconfig*.json`, `.env.example`（`VITE_TOKEN_ADDRESS`, `VITE_CHAIN_ID`, `VITE_RPC`）。
+## 変更点（教材改訂後）
+- DApp は `dapp/` に同梱（新規 `npm create vite` は不要）。
+- Vite の環境変数は `dapp/.env.local` を使う（`VITE_*`）。
 
-## コマンド
-```
+## 実行
+```bash
 cd dapp
-npm install
+npm ci
 npm run build
 ```
-→ `vite build` が成功し、`dist/` に成果物を生成。
 
-## 実装ポイント
-- ethers v6 を利用し、`BrowserProvider` + `getSigner()` でアカウントを取得。
-- `window.ethereum.on('accountsChanged'|'chainChanged')` でUIを再読み込み。
-- `Switch to Chain` ボタンは `wallet_switchEthereumChain` を呼び、`.env` の `VITE_CHAIN_ID` を目標チェーンとして使用。
-- `Send` ボタンは `ethers.parseUnits` で任意桁数に対応し、トランザクション完了後に残高をリフレッシュ。
+### 結果（抜粋）
+- `tsc && vite build` が成功。
+- 生成物：
+  - `dist/index.html`：0.32 kB
+  - `dist/assets/index-*.js`：412.60 kB（gzip: 145.38 kB）
 
-## 動作確認
-- `npm run build` により TypeScript / Vite ビルドを通過。ブラウザで `npm run dev` を実行すれば MetaMask と連携可能（ローカル Hardhat RPC でも動作）。
-- `.env.example` の値をコピーして `.env` を作成し、`VITE_TOKEN_ADDRESS` を Day05 で発行したトークンアドレス（例: `0x6101...`）へ差し替えることで即テスト可能。
+## 次に行うとよい確認（ブラウザ必須）
+1) `cp dapp/.env.example dapp/.env.local`  
+2) `dapp/.env.local` に `VITE_CHAIN_ID` / `VITE_TOKEN_ADDRESS` を設定  
+3) `npm run dev` で `http://localhost:5173` を開き、Connect/Switch/Refresh/Send を確認
 
-## まとめ
-1. Day09 で要求される DApp フロントの基本機能（接続/切替/残高/送金）を React + Vite で実装。
-2. ビルドが通る形でテンプレート化したため、`npm run dev` で容易にホットリロード開発が可能。
-3. ハードハットでローカルに立てた ERC-20 (`MyToken`) の送金UIとしても再利用できる。
+## 補足
+- `npm ci` 実行時に `npm audit` の脆弱性警告が出たため、依存更新は別途対応候補（動作確認優先で今回は未対応）。

--- a/reports/Day10.md
+++ b/reports/Day10.md
@@ -1,40 +1,28 @@
-# Day10 実行ログ
+# Day10 実行ログ（2026-01 更新）
 
-## 実装
-- `contracts/EventToken.sol`：`mint` / `transfer` と `TransferLogged` イベントを備えた教材用トークンを追加。
-- テスト: `test/eventtoken.ts` でイベント発火と残高更新を検証。
-- スクリプト:
-  - `scripts/deploy-event-token.ts`
-  - `scripts/use-event-token.ts`（mint→transfer でイベント発火）
-- `dapp/` へイベント購読フックを追加：`src/hooks/useEvents.ts` と `App.tsx` の UI 拡張。
-  - `.env.example` に `VITE_EVENT_TOKEN` を追記し、購読対象アドレスを設定できるようにした。
+## 実行（localhost）
+1) Hardhat node を起動  
+2) `EventToken` をデプロイ  
+3) `mint`→`transfer` を実行して `TransferLogged` を発火  
 
-## コマンド
+```bash
+npx hardhat node
 ```
-# コントラクトテスト
-npx hardhat test
 
-# ローカルデプロイ & 送金
+別ターミナルで：
+```bash
 npx hardhat run scripts/deploy-event-token.ts --network localhost
-EVT=0x3Aa5ebB10DC797CAC828524e59A333d0A371443c \
+EVT=0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0 \
   npx hardhat run scripts/use-event-token.ts --network localhost
-
-# DAppビルド（イベント購読機能込）
-cd dapp && npm run build
 ```
-テスト結果：`10 passing`（EventTokenを含む）。
 
-## DApp 表示
-- `VITE_EVENT_TOKEN` を設定すると `useTransferEvents` が `TransferLogged` イベントをリアルタイム購読し、最新30件をUIに表示。
-- Hardhat ローカルRPCでも `wallet_switchEthereumChain` + `MetaMask` でログを確認可能。
+### 結果（抜粋）
+- `EventToken: 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0`
+- `transfer complete { to: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8' }`
 
-## The Graph について
-- `graph-cli` を使ったサブグラフ生成はホスト側APIキー・アクセスが必要になるため、ここでは雛形コマンドと `schema.graphql` / `mapping.ts` のサンプルを README（カリキュラム）どおり参照する形に留めた。CLI自体は `npm i -g @graphprotocol/graph-cli` で導入可能。
+## DApp（ブラウザ確認が必要）
+- `dapp/.env.local` に `VITE_EVENT_TOKEN=0x9fE...` を設定すると、`Recent TransferLogged events` の表示が有効になる。
+- ただし `dapp/` は injected provider（MetaMask等）前提のため、この環境ではUI表示まで未確認。
 
-## デプロイ記録
-- `DEPLOYMENTS.md` に `EventToken (localhost)` を追記し、イベント購読用アドレスを共有。
-
-## まとめ
-1. イベント発火コントラクトとHardhatテスト・スクリプト・DApp購読機能を追加し、Day10要件をローカルで一通り再現。
-2. DAppは connect/switch/transfer UIに「Recent TransferLogged events」リストを表示し、ブラウザだけでイベントの挙動を確認できる。
-3. The Graph はコマンドテンプレートを参照しつつ、APIキー準備後に `graph init` → `graph deploy` を行えば本番環境へ拡張できる構成になっている。
+## The Graph（未実施）
+- 生成物は同梱しない運用。`subgraph/README.md` と `appendix/the-graph.md` を参照。

--- a/reports/Day11.md
+++ b/reports/Day11.md
@@ -1,28 +1,26 @@
-# Day11 実行ログ
+# Day11 実行ログ（2026-01 更新）
 
-## 実装確認
-- `contracts/MyNFT.sol` / `FixedPriceMarket.sol`：Day11教材どおりのロイヤリティ対応NFTと固定価格マーケットがリポジトリに存在することを再確認。
-- 新規テスト `test/market.ts` を追加し、`list`→`buy` で `FixedPriceMarket` がNFTを移転させる流れを自動テスト化。
-- 既存 `test/mynft.ts` で `tokenURI` を検証済み。
+## 実行（localhost）
+NFT の `tokenURI` が `.../<id>.json` になることを、ローカルで確認した。
 
-## コマンド
+```bash
+npx hardhat node
 ```
-# 全テスト（MyNFT + Market 含む）
-npx hardhat test
-→ 11 passing（MyToken, EventToken, GasBench, Hello, FixedPriceMarket, MyNFT, WalletBox）
 
-# ローカルデプロイ例
+別ターミナルで：
+```bash
 npx hardhat run scripts/deploy-nft.ts --network localhost
-NFT_ADDRESS=0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e \
+NFT_ADDRESS=0x5FC8d32690cc91D4c39d9d3abcBD16989F875707 \
   npx hardhat run scripts/mint-nft.ts --network localhost
-npx hardhat run scripts/deploy-event-token.ts --network localhost   # Day10連携
 ```
-- `FixedPriceMarket` テストでは `setApprovalForAll`→`list`→`buy` を通し、新しいオーナーが `buyer` になることを確認。
 
-## IPFS / OpenSea
-- 実際のIPFSアップロードやOpenSeaテストネット確認はAPIキー・画像ファイルが必要なため未実施。`NFT_BASE=ipfs://cid/` 等を `.env` に設定すれば `scripts/deploy-nft.ts`/`mint-nft.ts` で即再現可能。
+### 結果（抜粋）
+- `MyNFT: 0x5FC8d32690cc91D4c39d9d3abcBD16989F875707`
+- `tokenURI: ipfs://example/1.json`
 
-## まとめ
-1. NFTロイヤリティ実装と最小マーケットプレイスの挙動をHardhatテストでカバーし、Day11の「IPFS→mint→販売」フローをコードレベルで再現。
-2. `scripts/deploy-nft.ts` / `mint-nft.ts` によりメタデータCIDとロイヤリティBPSを環境変数から変更できる状態を整備。
-3. 今後は実ネットワークでのVerify・OpenSea表示確認を `.env` と `npx hardhat verify` コマンドで行うだけで良い状態になった。
+## IPFS 表示確認（未実施）
+- OpenSea はテストネット表示を終了しているため、`tokenURI` を HTTP Gateway（例：`https://ipfs.io/ipfs/<CID>/1.json`）に置き換えて確認する流れになる。
+- 実際のIPFSアップロードは APIキーや素材ファイルが必要なため未実施。
+
+## Market（FixedPriceMarket）
+- `test/market.ts` が `list`→`buy` の最小フローを自動テストしている（UIは未実施）。


### PR DESCRIPTION
## Summary
- Update execution reports to match the latest curriculum changes (PR#6).
- Refresh Day05/08/09/10/11/14 reports with current commands/outputs and updated assumptions (bundled `dapp/`, `tokenURI` `.json`, OpenSea testnets sunset, etc.).

## Validation
- `npm test`
- `cd dapp && npm ci && npm run build`
