### PR TITLE
docs/code: refresh reports and fix fee calculation scripts

### DIFF
--- a/reports/Day01.md
+++ b/reports/Day01.md
@@ -1,41 +1,69 @@
-# Day01 実行ログ
+# Day01 実行ログ（2026-01 更新）
 
 ## 環境
 - RPC: `http://127.0.0.1:8545`（ローカル Hardhat node）
-- Hardhat node は `npx hardhat node` でバックグラウンド起動
+- Day01 本文は Sepolia RPC 前提だが、今回はローカルで再現（APIキー不要）。
+
+## 実行
+```bash
+./node_modules/.bin/hardhat node
+export RPC=http://127.0.0.1:8545
+```
 
 ## コマンドと結果
 
 ### 最新ブロック番号
-```
-curl -s -X POST $RPC --data '{"method":"eth_blockNumber"}'
-→ 0x3 (decimal 3)
+```bash
+curl -s -X POST $RPC \
+  -H 'Content-Type: application/json' \
+  --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq -r .result
+# => 0x3
 ```
 
 ### ブロック詳細（#0）
+```bash
+curl -s -X POST $RPC \
+  -H 'Content-Type: application/json' \
+  --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x0", true],"id":2}' \
+  | jq '{number: .result.number, hash: .result.hash, baseFeePerGas: .result.baseFeePerGas, gasUsed: .result.gasUsed, gasLimit: .result.gasLimit, miner: .result.miner, timestamp: .result.timestamp, transactions: (.result.transactions|length)}'
 ```
+
+出力（抜粋）：
+```json
 {
   "number": "0x0",
-  "hash": "0xa8a6...",
+  "hash": "0x6a865ec00f0a285a3ea37de8372d022f0156e5e4b46cd81044b7850d891b8cf4",
   "baseFeePerGas": "0x3b9aca00",
   "gasUsed": "0x0",
   "gasLimit": "0x1c9c380",
-  "miner": "0x000...000",
-  "timestamp": "0x69162929",
+  "miner": "0x0000000000000000000000000000000000000000",
+  "timestamp": "0x69630a46",
   "transactions": 0
 }
 ```
 
-### 3ブロック分の混雑度
-| Block | gasUsed | gasLimit | congestion |
-|-------|---------|----------|------------|
-| 0x3 | 0x5208 | 0x1c9c380 | 0.0007 |
-| 0x2 | 0x5208 | 0x1c9c380 | 0.0007 |
-| 0x1 | 0x5208 | 0x1c9c380 | 0.0007 |
+### ブロックを進める（Txを3回送る）
+```bash
+A0=$(curl -s -X POST $RPC -H 'Content-Type: application/json' \
+  --data '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}' | jq -r '.result[0]')
+A1=$(curl -s -X POST $RPC -H 'Content-Type: application/json' \
+  --data '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}' | jq -r '.result[1]')
 
-（Block #1〜#3 は `eth_sendTransaction` を3回実行して生成）
+for i in 1 2 3; do
+  curl -s -X POST $RPC -H 'Content-Type: application/json' \
+    --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"from":"'"$A0"'","to":"'"$A1"'","value":"0x1"}],"id":'"$i"'}' \
+    | jq -r .result
+done
+```
+
+### 3ブロック分の混雑度（`gasUsed/gasLimit`）
+| Block | gasUsed | gasLimit | congestion |
+|-------|--------:|---------:|-----------:|
+| 0x1 | 21,000 | 30,000,000 | 0.000700 |
+| 0x2 | 21,000 | 30,000,000 | 0.000700 |
+| 0x3 | 21,000 | 30,000,000 | 0.000700 |
 
 ## 学び
-1. Hardhat ローカルノードでも RPC 手順は同様に再現できる。
-2. `eth_sendTransaction` を使えば手動でブロックを進められ、混雑度計算も確認可能。
-3. Genesis ブロックは `eth_getBlockByNumber("0x0")` で取得し、`jq '.result | ...'` で主要フィールドを抽出する。
+1. ローカルノードでも JSON-RPC の基本操作（`eth_blockNumber` / `eth_getBlockByNumber`）は再現できる。
+2. `eth_sendTransaction`（unlock済みアカウント）でTxを投げると、ブロックを手動で進められる。
+3. `gasUsed/gasLimit` はブロック混雑の目安になる（ただし L1/L2 の“手数料”そのものとは別）。

--- a/reports/Day02.md
+++ b/reports/Day02.md
@@ -1,21 +1,22 @@
-# Day02 実行ログ
+# Day02 実行ログ（2026-01 更新）
 
 ## 環境
-- RPC: `http://127.0.0.1:8545`（Day01 と同じ Hardhat node を継続使用）
+- RPC: `http://127.0.0.1:8545`（ローカル Hardhat node）
 - サンプルコントラクト: `contracts/GasTest.sol`
 - ドライバースクリプト: `scripts/day02_gas.ts`
 
 ## 実行手順
-1. `npx hardhat compile`
-2. `npx hardhat run scripts/day02_gas.ts --network localhost`
-3. `curl -X POST ... eth_getTransactionReceipt` で `store` Tx を解析
+1. `./node_modules/.bin/hardhat node`
+2. `npx hardhat compile`
+3. `npx hardhat run scripts/day02_gas.ts --network localhost`
+4. `curl -X POST ... eth_getTransactionReceipt` で `store` Tx を解析
 
 ## Gas 計測結果
 | 呼び出し | Tx Hash | Gas Used | Effective Gas Price (wei) | 手数料 (ETH) |
 |----------|---------|---------|---------------------------|--------------|
-| `store(123)` | `0xb2538ac1...` | 43,516 | 1,393,966,933 | 6.07e-05 |
-| `add(10,20)` | `0x78015d00...` | 21,860 | 1,346,601,148 | 2.94e-05 |
-| `testRewrite(123)` | `0x09c46ca8...` | 23,638 | 1,303,944,076 | 3.08e-05 |
+| `store(123)` | `0xba728419...` | 43,516 | 970,068,939 | 4.221e-05 |
+| `add(10,20)` | `0xcd44a299...` | 21,860 | 849,162,102 | 1.856e-05 |
+| `testRewrite(123)` | `0x5306f1d4...` | 23,638 | 743,171,529 | 1.757e-05 |
 
 - `add()` は pure 関数のため、そのまま呼ぶと `call` になってしまう。`encodeFunctionData` で calldata を生成し、`sendTransaction` で Tx を作成してGasを取得。
 - `testRewrite()` は同じ値を再書込みした結果、`store()` よりガスが少なくなり、Refund を確認できた。
@@ -27,11 +28,11 @@ curl -s -X POST http://127.0.0.1:8545 \
   --data '{
     "jsonrpc":"2.0",
     "method":"eth_getTransactionReceipt",
-    "params":["0xb2538ac1859d90aed435e627a4b234f3072076bddc4f23095025474976c7665c"],
+    "params":["0xba7284193ee601b6787921d03a78bf8ce1e1fe35359447754cbe1872750970be"],
     "id":10
   }' | jq '.result | {blockNumber, gasUsed, effectiveGasPrice, status}'
 ```
-→ `gasUsed`: `0xa9fc`, `effectiveGasPrice`: `0x53163f55`, `status`: `0x1`
+→ `gasUsed`: `0xa9fc`, `effectiveGasPrice`: `0x39d213cb`, `status`: `0x1`
 
 ## 学び
 1. `pure/view` 関数であっても raw Tx を組めばガス計測が可能。

--- a/reports/Day03.md
+++ b/reports/Day03.md
@@ -1,8 +1,8 @@
-# Day03 実行ログ
+# Day03 実行ログ（2026-01 更新）
 
 ## 環境確認
 - Node.js: `v22.19.0`
-- npm: `11.6.2`
+- npm: `11.7.0`
 - Hardhat: `2.27.0` (`npx hardhat --version`)
 - Foundry: `forge/cast/anvil/chisel 1.4.4-stable`（`~/.foundry/bin/foundryup`で導入）
 - RPC: ローカル Hardhat node (`http://127.0.0.1:8545`)
@@ -11,11 +11,11 @@
 - 既存ブートキャンプリポジトリをそのまま使用。
 - 主要コマンド：
   - `npx hardhat compile` → 変更なし、既存契約を再コンパイル。
-  - `npx hardhat test` → Hello / GasBench のサンプルテストがすべて成功（4 passing）。
+  - `npx hardhat test` → 既存テストがすべて成功（16 passing）。
 - `.env.example` に外部RPC項目は揃っているが、今回の検証ではローカルRPCのみ利用。
 
 ## Foundry 連携
-- `~/.foundry/bin/cast block-number --rpc-url http://127.0.0.1:8545` → `9`
+- `~/.foundry/bin/cast block-number --rpc-url http://127.0.0.1:8545` → `0`
 - `cast` コマンドがローカルRPCへ接続できることを確認。
 
 ## 未実施項目 / 注意

--- a/reports/Day04.md
+++ b/reports/Day04.md
@@ -1,4 +1,4 @@
-# Day04 実行ログ
+# Day04 実行ログ（2026-01 更新）
 
 ## 実装
 - `contracts/WalletBox.sol` を教材どおりに追加（`NotOwner`/`EmptyMessage` カスタムエラー、`receive()` ログ、`withdraw` のCEI順守）。
@@ -10,18 +10,20 @@
 
 ## コマンド
 ```
-# ビルド & テスト
-npx hardhat test
+# WalletBox のテストのみ
+npx hardhat test test/walletbox.ts
+# => 3 passing
 
 # ローカルネットへデプロイ例
+./node_modules/.bin/hardhat node
 npx hardhat run scripts/deploy-walletbox.ts --network localhost
-→ WalletBox: 0x8A791620dd6260079BF849Dc5567aDC3F2FdC318
+→ WalletBox: 0x5FbDB2315678afecb367f032d93F642f64180aa3
 ```
-テスト結果：`7 passing`（GasBench/Hello/WalletBox）。
+全体テストは `npx hardhat test` で `16 passing` を確認。
 
 ## 観測事項
 - `ethers.parseEther` / `waitForDeployment()` など ethers v6 API へ置き換え済み。
-- `withdraw` の事件検証でイベント引数もアサートして CEI + custom error の動作を確認。
+- `withdraw` の挙動検証でイベント引数もアサートして CEI + custom error の動作を確認。
 
 ## 未実施
 - Sepolia デプロイは `.env` に RPC / PRIVATE_KEY を設定していないため未実行。環境が整い次第、`npx hardhat run scripts/deploy-walletbox.ts --network sepolia` で再現可能。

--- a/reports/Day05.md
+++ b/reports/Day05.md
@@ -6,26 +6,26 @@
 
 ## 実行（localhost）
 ```bash
-npx hardhat node
+./node_modules/.bin/hardhat node
 ```
 
 別ターミナルで：
 ```bash
 # ERC-20 deploy
 npx hardhat run scripts/deploy-token.ts --network localhost
+# → MTK: <TOKEN>
 
 # transfer
-TOKEN=0x5FbDB2315678afecb367f032d93F642f64180aa3 \
-  npx hardhat run scripts/token-transfer.ts --network localhost
+TOKEN=<TOKEN> npx hardhat run scripts/token-transfer.ts --network localhost
 
 # approve -> transferFrom（複数署名者を使う）
-TOKEN=0x5FbDB2315678afecb367f032d93F642f64180aa3 \
-  npx hardhat run scripts/token-approve.ts --network localhost
+TOKEN=<TOKEN> npx hardhat run scripts/token-approve.ts --network localhost
 
 # ERC-721 deploy & mint
 npx hardhat run scripts/deploy-nft.ts --network localhost
-NFT_ADDRESS=0x5FC8d32690cc91D4c39d9d3abcBD16989F875707 \
-  npx hardhat run scripts/mint-nft.ts --network localhost
+# → MyNFT: <NFT_ADDRESS>
+
+NFT_ADDRESS=<NFT_ADDRESS> npx hardhat run scripts/mint-nft.ts --network localhost
 ```
 
 ### 結果（抜粋）
@@ -37,7 +37,9 @@ NFT_ADDRESS=0x5FC8d32690cc91D4c39d9d3abcBD16989F875707 \
 - `token-approve.ts`：
   - `allowance: 1000000000000000000`
   - `transferFrom complete`
-- `MyNFT: 0x5FC8d32690cc91D4c39d9d3abcBD16989F875707`
+- `MyNFT: 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9`
+- `mint-nft.ts`：
+  - `minted: { to: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8', tokenId: '1' }`
 - `tokenURI: ipfs://example/1.json`
 
 ## 未実施（外部依存）

--- a/reports/Day06.md
+++ b/reports/Day06.md
@@ -1,4 +1,4 @@
-# Day06 実行ログ
+# Day06 実行ログ（2026-01 更新）
 
 ## 対象
 - `contracts/GasBench.sol`：`benchSumMemory/benchSumCalldata` を持つベンチ用コントラクト。
@@ -6,8 +6,12 @@
 - `curriculum/Day06_Local_Testing.md` は既に bench 方針を説明済み。
 
 ## コマンド
-```
-npx hardhat test
+```bash
+# GasBench のみ（gas reporter の表が出る）
+npx hardhat test test/gasbench.ts
+
+# 参考：Hello のみ（gas reporter の表が出る）
+npx hardhat test test/hello.ts
 ```
 > Gas reporter を有効化しているため、テスト完了時に関数単位のgas表が出力される。
 
@@ -28,7 +32,7 @@ memory vs calldata の差分（123,548 vs 91,860）を gasReporter 上で確認�
 - `emitMany(n)` の n=5 でイベントガスコストを比較可能。
 
 ## 追加検証
-- `npm ci` → `npx hardhat test` を CI 相当の流れで実行し、全テスト（GasBench/Hello/MyToken/MyNFT/WalletBox）の合計 9 ケースが成功していることも再確認。
+- `npm ci` → `npm test` を CI 相当の流れで実行し、全テスト `16 passing` を再確認。
 
 ## まとめ
 1. bench関数経由で memory / calldata / event cost を数値化できる状態を構築済み。

--- a/reports/Day08.md
+++ b/reports/Day08.md
@@ -7,21 +7,21 @@
 
 ## 実行（localhost）
 ```bash
-npx hardhat node
+./node_modules/.bin/hardhat node
 ```
 
 別ターミナルで：
 ```bash
 # 事前にERC-20をデプロイ（例）
 npx hardhat run scripts/deploy-token.ts --network localhost
+# → MTK: <TOKEN>
 
 # 送金の手数料計測（宛先や金額は任意で上書きできる）
 npx hardhat run scripts/measure-fee.ts --network localhost | tee metrics/fee-local.json
 cat metrics/fee-local.json | tools/to-csv.sh > metrics/metrics.csv
 
 # ERC-20 transfer 計測
-TOKEN=0x5FbDB2315678afecb367f032d93F642f64180aa3 \
-  npx hardhat run scripts/measure-contract.ts --network localhost | tee metrics/contract-local.json
+TOKEN=<TOKEN> npx hardhat run scripts/measure-contract.ts --network localhost | tee metrics/contract-local.json
 cat metrics/contract-local.json | tools/to-csv.sh >> metrics/metrics.csv
 ```
 
@@ -32,9 +32,12 @@ cat metrics/contract-local.json | tools/to-csv.sh >> metrics/metrics.csv
   "network": "localhost",
   "chainId": 31337,
   "txHash": "0x11672f988af75c5527c63a6dd9fbb1dd4015ff7ba39b5f8b45dd7262d12ac9d8",
+  "to": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+  "valueWei": "100000000000000",
   "gasUsed": "21000",
-  "feeEth": "0.0",
-  "latencyMs": 16
+  "effGasPriceWei": "444855188",
+  "feeEth": "0.000009341958948",
+  "latencyMs": 18
 }
 ```
 
@@ -45,9 +48,12 @@ cat metrics/contract-local.json | tools/to-csv.sh >> metrics/metrics.csv
   "chainId": 31337,
   "txHash": "0x8ea292b948fda640138368509dfdb2895e15b1f35213fd511cff600f581733e1",
   "gasUsed": "34508",
-  "feeEth": "0.0",
-  "latencyMs": 16
+  "to": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+  "amount": "10000000000000000",
+  "effGasPriceWei": "389326139",
+  "feeEth": "0.000013434866404612",
+  "latencyMs": 19
 }
 ```
 
-> ローカルHardhat node は `gasPrice=0` のため `feeEth` は `0.0` になる。実ネットワークで実行すればそのまま有効な数値を取得できる。
+> `feeEth` は `gasUsed * effectiveGasPrice` で計算している。手数料の比較（L1/L2差分）を目的にする場合は、Sepolia/Optimism 等の実ネットワークで計測する。

--- a/reports/Day09.md
+++ b/reports/Day09.md
@@ -15,7 +15,7 @@ npm run build
 - `tsc && vite build` が成功。
 - 生成物：
   - `dist/index.html`：0.32 kB
-  - `dist/assets/index-*.js`：412.60 kB（gzip: 145.38 kB）
+  - `dist/assets/index-*.js`：402.25 kB（gzip: 142.68 kB）
 
 ## 次に行うとよい確認（ブラウザ必須）
 1) `cp dapp/.env.example dapp/.env.local`  
@@ -23,4 +23,4 @@ npm run build
 3) `npm run dev` で `http://localhost:5173` を開き、Connect/Switch/Refresh/Send を確認
 
 ## 補足
-- `npm ci` 実行時に `npm audit` の脆弱性警告が出たため、依存更新は別途対応候補（動作確認優先で今回は未対応）。
+- `npm audit`：0 vulnerabilities を確認。

--- a/reports/Day10.md
+++ b/reports/Day10.md
@@ -6,22 +6,23 @@
 3) `mint`→`transfer` を実行して `TransferLogged` を発火  
 
 ```bash
-npx hardhat node
+./node_modules/.bin/hardhat node
 ```
 
 別ターミナルで：
 ```bash
 npx hardhat run scripts/deploy-event-token.ts --network localhost
-EVT=0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0 \
-  npx hardhat run scripts/use-event-token.ts --network localhost
+# → EventToken: <EVT>
+
+EVT=<EVT> npx hardhat run scripts/use-event-token.ts --network localhost
 ```
 
 ### 結果（抜粋）
-- `EventToken: 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0`
+- `EventToken: 0x5FbDB2315678afecb367f032d93F642f64180aa3`
 - `transfer complete { to: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8' }`
 
 ## DApp（ブラウザ確認が必要）
-- `dapp/.env.local` に `VITE_EVENT_TOKEN=0x9fE...` を設定すると、`Recent TransferLogged events` の表示が有効になる。
+- `dapp/.env.local` に `VITE_EVENT_TOKEN=<EVT>` を設定すると、`Recent TransferLogged events` の表示が有効になる。
 - ただし `dapp/` は injected provider（MetaMask等）前提のため、この環境ではUI表示まで未確認。
 
 ## The Graph（未実施）

--- a/reports/Day11.md
+++ b/reports/Day11.md
@@ -4,18 +4,19 @@
 NFT の `tokenURI` が `.../<id>.json` になることを、ローカルで確認した。
 
 ```bash
-npx hardhat node
+./node_modules/.bin/hardhat node
 ```
 
 別ターミナルで：
 ```bash
 npx hardhat run scripts/deploy-nft.ts --network localhost
-NFT_ADDRESS=0x5FC8d32690cc91D4c39d9d3abcBD16989F875707 \
-  npx hardhat run scripts/mint-nft.ts --network localhost
+# → MyNFT: <NFT_ADDRESS>
+
+NFT_ADDRESS=<NFT_ADDRESS> npx hardhat run scripts/mint-nft.ts --network localhost
 ```
 
 ### 結果（抜粋）
-- `MyNFT: 0x5FC8d32690cc91D4c39d9d3abcBD16989F875707`
+- `MyNFT: 0x5FbDB2315678afecb367f032d93F642f64180aa3`
 - `tokenURI: ipfs://example/1.json`
 
 ## IPFS 表示確認（未実施）

--- a/reports/Day12.md
+++ b/reports/Day12.md
@@ -1,4 +1,4 @@
-# Day12 実行ログ
+# Day12 実行ログ（2026-01 更新）
 
 ## 実装
 - 脆弱/安全コントラクト：`contracts/VulnBank.sol`, `SafeBank.sol`, `Attacker.sol` を追加。VulnBankはCEI違反（`bal`更新が送金後）で再入攻撃可能、SafeBankは `ReentrancyGuard` + CEI 順守。
@@ -6,16 +6,16 @@
 - テスト：`test/reentrancy.ts` を実装し、VulnBankが攻撃で枯渇する一方、SafeBankは攻撃Txがrevertすることを確認。
 
 ## コマンド
-```
+```bash
 # 依存を復元（OZ v5）
 npm ci
 
 # 再入テストのみ
 npx hardhat test test/reentrancy.ts
 # 全体テスト
-npx hardhat test
+npm test
 ```
-結果：全11ケース成功（MyToken, EventToken, GasBench, Hello, FixedPriceMarket, MyNFT, Reentrancy x2, WalletBox）。
+結果：`test/reentrancy.ts` は `2 passing`、全体は `16 passing`。
 
 ## 観測
 - `VulnBank` へ10 ETH預けた状態で `Attacker.attack()` を実行すると、`bal[msg.sender]` が未更新の間に再入され、残高が9 ETH未満まで減少。

--- a/reports/Day14.md
+++ b/reports/Day14.md
@@ -7,7 +7,7 @@
 
 ## 実行
 ```bash
-npx hardhat node
+./node_modules/.bin/hardhat node
 ```
 
 別ターミナルで：
@@ -18,35 +18,45 @@ npx hardhat run scripts/deploy-event-token.ts --network localhost
 npx hardhat run scripts/deploy-nft.ts --network localhost
 
 # Use
-TOKEN=0x5FbDB2315678afecb367f032d93F642f64180aa3 \
-  npx hardhat run scripts/token-transfer.ts --network localhost
+TOKEN=<TOKEN> npx hardhat run scripts/token-transfer.ts --network localhost
 
-EVT=0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0 \
-  npx hardhat run scripts/use-event-token.ts --network localhost
+EVT=<EVT> npx hardhat run scripts/use-event-token.ts --network localhost
 
-NFT_ADDRESS=0x5FC8d32690cc91D4c39d9d3abcBD16989F875707 \
-  npx hardhat run scripts/mint-nft.ts --network localhost
+NFT_ADDRESS=<NFT_ADDRESS> npx hardhat run scripts/mint-nft.ts --network localhost
 
 # Measure
 npx hardhat run scripts/measure-fee.ts --network localhost
-TOKEN=0x5FbDB2315678afecb367f032d93F642f64180aa3 \
-  npx hardhat run scripts/measure-contract.ts --network localhost
+TOKEN=<TOKEN> npx hardhat run scripts/measure-contract.ts --network localhost
 ```
 
 ## 結果（抜粋）
 - `MyToken: 0x5FbDB2315678afecb367f032d93F642f64180aa3`
-- `EventToken: 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0`
-- `MyNFT: 0x5FC8d32690cc91D4c39d9d3abcBD16989F875707`
+- `EventToken: 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512`
+- `MyNFT: 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0`
 
 `measure-fee.ts`：
 ```json
-{"network":"localhost","chainId":31337,"txHash":"0x11672f...","gasUsed":"21000","feeEth":"0.0"}
+{
+  "network": "localhost",
+  "chainId": 31337,
+  "txHash": "0x11672f988af75c5527c63a6dd9fbb1dd4015ff7ba39b5f8b45dd7262d12ac9d8",
+  "gasUsed": "21000",
+  "effGasPriceWei": "444855188",
+  "feeEth": "0.000009341958948"
+}
 ```
 `measure-contract.ts`：
 ```json
-{"network":"localhost","chainId":31337,"txHash":"0x8ea292...","gasUsed":"34508","feeEth":"0.0"}
+{
+  "network": "localhost",
+  "chainId": 31337,
+  "txHash": "0x8ea292b948fda640138368509dfdb2895e15b1f35213fd511cff600f581733e1",
+  "gasUsed": "34508",
+  "effGasPriceWei": "389326139",
+  "feeEth": "0.000013434866404612"
+}
 ```
-> ローカルHardhat node は `gasPrice=0` のため `feeEth` は `0.0` になる。実ネットワークでは実費が出る。
+> `feeEth` は `gasUsed * effectiveGasPrice` で計算している。実ネットワーク（Sepolia/Optimism等）では価格が変動するため、比較したい場合は同じ条件で複数回計測する。
 
 ## DApp / Verify / CI / The Graph（入口）
 - DApp：`cd dapp && npm ci && npm run build` が成功（UI動作はMetaMask等が必要）。


### PR DESCRIPTION
## Summary
- Fix `scripts/measure-fee.ts` / `scripts/measure-contract.ts` to compute `feeEth` from JSON-RPC receipt `effectiveGasPrice` (Hardhat receipt did not populate `receipt.effectiveGasPrice`, which previously caused `feeEth: 0`).
- Refresh execution logs in `reports/Day01.md` .. `reports/Day14.md` (selected days) to match current main and the updated measurement output.

## Verification
- `npm test` (16 passing)
- `cd dapp && npm run build`
