### PR TITLE
docs/site: title fallback + TOC nav + JP labels

### DIFF
--- a/_includes/page-navigation.html
+++ b/_includes/page-navigation.html
@@ -170,7 +170,7 @@ display ToC titles even when order falls back to site.pages.
       </span>
     {% endif %}
 
-    <a href="{{ '/' | relative_url }}" class="nav-home">
+    <a href="{{ '/curriculum/TOC/' | relative_url }}" class="nav-home">
       <span class="icon">📚</span>
       <span class="label">目次へ</span>
     </a>

--- a/_layouts/book.html
+++ b/_layouts/book.html
@@ -1,12 +1,63 @@
 <!DOCTYPE html>
 <html lang="{{ page.lang | default: site.lang | default: 'ja' }}" data-theme="light">
 <head>
+    {%- comment -%}
+    Resolve a sensible page title even when Markdown pages have no front matter.
+    Priority: page.title > navigation title match > site.title
+    {%- endcomment -%}
+    {%- assign resolved_title = page.title -%}
+    {%- assign navigation = site.data.navigation -%}
+    {%- assign _baseurl = site.baseurl | default: '' -%}
+    {%- assign page_url_n = page.url -%}
+    {%- if _baseurl and _baseurl != '' -%}
+      {%- assign page_url_n = page_url_n | remove_first: _baseurl -%}
+    {%- endif -%}
+
+    {%- if resolved_title == nil or resolved_title == '' -%}
+      {%- assign data_items = "" | split: "|" -%}
+      {%- if navigation -%}
+        {%- if navigation.introduction -%}
+          {%- assign data_items = data_items | concat: navigation.introduction -%}
+        {%- endif -%}
+
+        {%- if navigation.chapters -%}
+          {%- assign chapters = navigation.chapters -%}
+          {%- assign first_chapter = chapters | first -%}
+          {%- if first_chapter.items -%}
+            {%- assign chapters_flat = "" | split: "|" -%}
+            {%- for part in chapters -%}
+              {%- if part.items -%}
+                {%- assign chapters_flat = chapters_flat | concat: part.items -%}
+              {%- endif -%}
+            {%- endfor -%}
+            {%- assign data_items = data_items | concat: chapters_flat -%}
+          {%- else -%}
+            {%- assign data_items = data_items | concat: chapters -%}
+          {%- endif -%}
+        {%- endif -%}
+
+        {%- if navigation.resources -%}
+          {%- assign data_items = data_items | concat: navigation.resources -%}
+        {%- endif -%}
+        {%- if navigation.appendices -%}
+          {%- assign data_items = data_items | concat: navigation.appendices -%}
+        {%- endif -%}
+      {%- endif -%}
+
+      {%- if data_items and data_items.size > 0 -%}
+        {%- assign match = data_items | where: "path", page_url_n | first -%}
+        {%- if match and match.title -%}
+          {%- assign resolved_title = match.title -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endif -%}
+
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{ page.description | default: site.description | escape }}">
     <meta name="author" content="{{ site.author | escape }}">
     
-    <title>{% if page.title %}{{ page.title | escape }} - {{ site.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
+    <title>{% if resolved_title and resolved_title != '' %}{{ resolved_title | escape }} - {{ site.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
     
     <!-- Preconnect to external domains -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -24,14 +75,14 @@
     <link rel="apple-touch-icon" href="{{ '/assets/images/itdo_logo_48x48_blue.png' | relative_url }}">
     
     <!-- Open Graph -->
-    <meta property="og:title" content="{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
+    <meta property="og:title" content="{% if resolved_title and resolved_title != '' %}{{ resolved_title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
     <meta property="og:description" content="{{ page.description | default: site.description | escape }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ page.url | absolute_url }}">
     
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
+    <meta name="twitter:title" content="{% if resolved_title and resolved_title != '' %}{{ resolved_title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
     <meta name="twitter:description" content="{{ page.description | default: site.description | escape }}">
     
     <!-- Theme Detection Script -->
@@ -72,7 +123,7 @@
             <div class="header-right">
                 <div class="search-container">
                     <input type="search" 
-                           placeholder="Search..." 
+                           placeholder="検索..." 
                            class="search-input"
                            id="search-input"
                            autocomplete="off">
@@ -138,7 +189,7 @@
                             <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
                             <path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4Z"></path>
                         </svg>
-                        Edit this page on GitHub
+                        このページをGitHubで編集
                     </a>
                 </div>
                 {% endif %}
@@ -155,4 +206,3 @@
 </body>
 <script src="{{ '/assets/js/safe-main.js' | relative_url }}"></script>
 </html>
-


### PR DESCRIPTION
GitHub Pages 側の読書体験を小さく改善します。

- 各ページのブラウザタブ/OGPタイトルを、front matter が無い場合でもナビの章名から解決
- 下部ナビの『目次へ』を `/curriculum/TOC/` に変更
- UI文言を最小限日本語化（検索プレースホルダ、編集リンク）

ローカルでは `npm test` が通過しています。