### PR TITLE
docs: polish Day06-07 and add reports links

### DIFF
--- a/curriculum/Day06_Local_Testing.md
+++ b/curriculum/Day06_Local_Testing.md
@@ -11,8 +11,15 @@
 
 ---
 
+## 0. 前提
+- ルートで `npm ci` 済み（依存が入っている）
+- 以降の手順は、このリポジトリ直下で実行する
+
+---
+
 ## 1. 事前準備
-プロジェクト直下で以下を実行。
+このリポジトリでは `solidity-coverage` と `hardhat-gas-reporter` は導入済みだ（`npm ci` で入る）。  
+ゼロから追加する場合は、プロジェクト直下で以下を実行する。
 ```bash
 npm i -D solidity-coverage hardhat-gas-reporter
 ```
@@ -183,3 +190,6 @@ jobs:
 - `npx hardhat test` と `coverage` の出力（スクリーンショット可）。
 - memory vs calldata、イベント数の差分を表に整理。
 - ガス最適化の所感を3行で記述。
+
+## 10. 実行例
+- 実行ログ例：[`reports/Day06.md`](../reports/Day06.md)

--- a/curriculum/Day07_Deploy_CI.md
+++ b/curriculum/Day07_Deploy_CI.md
@@ -133,7 +133,7 @@ GitHub > Settings > Environments > `production` を作成し、**Required review
 1. **小額**でL2（例：Optimism）へ先行デプロイ。
 2. Etherscan/BlockscoutでVerify。
 3. DApp・サブグラフ・モニタを接続して動作確認（Day10以降）。
-4. Mainnetに本デプロイ。`DEPLOYMENTS.md`更新、リリースタグ付与。
+4. Mainnetに本デプロイ。[`DEPLOYMENTS.md`](../DEPLOYMENTS.md) を更新し、リリースタグを付与する。
 
 ---
 
@@ -150,5 +150,8 @@ GitHub > Settings > Environments > `production` を作成し、**Required review
 ## 8. 提出物
 - デプロイログ一式（ネットワーク、アドレス、TxHash）。
 - Etherscan/BlockscoutのVerifyリンク。
-- `DEPLOYMENTS.md`の追記差分。
+- [`DEPLOYMENTS.md`](../DEPLOYMENTS.md) の追記差分。
 - GitHub Actions実行ページのスクリーンショット（承認→完了）。
+
+## 9. 実行例
+- 実行ログ例：[`reports/Day07.md`](../reports/Day07.md)


### PR DESCRIPTION
Part2（Day06〜Day07）の書籍向け微修正です。

- Day06: 0.前提を追加し、このリポジトリでは計測系プラグイン導入済みである点を明記
- Day06/Day07: 章末に実行ログ例（reports）へのリンクを追加
- Day07: DEPLOYMENTS.md 参照をリンク化

ローカルでは npm test が通過しています。