### PR TITLE
docs: polish Day11-14 and strengthen troubleshooting

### DIFF
--- a/appendix/ci-github-actions.md
+++ b/appendix/ci-github-actions.md
@@ -11,10 +11,23 @@
 - Node.js のバージョン違い：ローカルとCIで `node -v` が違うと落ちやすい。
 - `npm install` ではなく `npm ci`：CIは `npm ci` 前提のほうが再現性が高い。
 
+### 失敗したときの最短デバッグ手順
+1) GitHub の Actions タブ → 該当 Run → **落ちた Step のログ**を開く。  
+2) ローカルで **CIと同じ手順**を再現する（このrepoは Node.js 20 前提）：
+```bash
+node -v
+npm ci
+npm test
+```
+3) `npm ci` が落ちる場合は、まず `package-lock.json` と `package.json` の差分（依存追加/更新漏れ）を疑う。
+
 ## 2. 手動承認付きデプロイ（workflow_dispatch + Environment）
 目的：誤デプロイを避けるため、**手動トリガ**＋**人間承認**でデプロイする。
 
 このリポジトリでは `.github/workflows/deploy.yml` を使う。
+
+### 2.0 どこから実行するか
+- GitHub の Actions タブ → `deploy` → `Run workflow`（手動実行）から起動する。
 
 ### 2.1 つまずき：承認が出ない
 - GitHub の Settings > Environments で `production` を作り、Required reviewers を設定する。
@@ -33,4 +46,3 @@
 
 ## 3. Verifyは別メモへ
 - Verify周りは `appendix/verify.md` を参照する。
-

--- a/appendix/verify.md
+++ b/appendix/verify.md
@@ -22,23 +22,32 @@
 ### 4.1 ネットワークを間違える
 - `--network` と、実際にデプロイしたチェーンが一致していることを確認する。
 
-### 4.2 コンストラクタ引数の不一致
+### 4.2 APIキーが未設定 / 空
+- `.env` の `ETHERSCAN_API_KEY`（または `OPTIMISTIC_ETHERSCAN_API_KEY`）が空だとVerifyできない。
+- `hardhat.config.ts` は `dotenv` を読むため、まず `.env` が存在することも確認する。
+
+### 4.3 コンストラクタ引数の不一致
 - もっとも多い原因。**引数の順序・型・値**が一致しないとVerifyが通らない。
 - 文字列（例：`ipfs://.../`）はクォートが必要なことがある：
   - 例：`"ipfs://<CID>/"`（空白を含む場合は必須）
 - デプロイ時の引数を [`DEPLOYMENTS.md`](../DEPLOYMENTS.md) やデプロイログに残しておくと再現しやすい。
 
-### 4.3 コンパイラ設定の不一致
+### 4.4 コンパイラ設定の不一致
 - `solidity` バージョン、optimizer（`runs`）、`viaIR` などがデプロイ時と一致しないと通らない。
 - “デプロイ後に `hardhat.config.ts` を変えた”場合は特に注意する。
 
-### 4.4 反映遅延（インデックス待ち）
+### 4.5 反映遅延（インデックス待ち）
 - デプロイ直後は、エクスプローラ側の取り込みが追いつかないことがある。
 - 少し待ってから再実行する。
 
-### 4.5 すでにVerify済み
+### 4.6 すでにVerify済み
 - すでにVerify済みの場合、エラー表示になることがある。
 - エクスプローラ側でソースが表示できるなら実害はない。
+
+### 4.7 同じファイルに複数コントラクトがある
+- 1ファイル内に複数コントラクトがある場合、Verify対象の指定が曖昧になって失敗することがある。
+- Hardhat Verify は `--contract` で fully qualified name（`path:ContractName`）を指定できる。
+  - 例：`npx hardhat verify --network sepolia --contract contracts/GasPack.sol:GasPacked <ADDRESS>`
 
 ## 5. 補足：L2 / Blockscout
 - L2はエクスプローラがEtherscan系とは限らない（Blockscout等）。

--- a/curriculum/Day11_NFT_Metadata.md
+++ b/curriculum/Day11_NFT_Metadata.md
@@ -11,11 +11,11 @@
 
 ---
 
-## 0. 事前準備
+## 0. 前提
 - PinataまたはInfura IPFS（Project ID/Secret）を用意。
 - 画像ファイル（例：`assets/1.png`）。
 
-`.env.example` 追記：
+`.env.example`（項目は同梱してあるので、`.env` に値を入れる）：
 ```
 NFT_BASE=ipfs://<CID>/
 NFT_ROYALTY_BPS=500   # 5% = 500 basis points
@@ -206,16 +206,20 @@ contract FixedPriceMarket {
 ---
 
 ## 7. テスト（抜粋）
-`test/nft.ts`
+`test/mynft.ts`
 ```ts
-import { expect } from "chai"; import { ethers } from "hardhat";
-describe("MyNFT",()=>{
-  it("mint+tokenURI", async()=>{
-    const [o,a] = await ethers.getSigners();
-    const F = await ethers.getContractFactory("MyNFT");
-    const c = await F.deploy("ipfs://cid/", o.address, 500); await c.waitForDeployment();
-    await (await c.mint(a.address,1)).wait();
-    expect(await c.tokenURI(1)).to.eq("ipfs://cid/1.json");
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+describe('MyNFT', () => {
+  it('mints and returns tokenURI', async () => {
+    const [owner, alice] = await ethers.getSigners();
+    const F = await ethers.getContractFactory('MyNFT');
+    const base = 'ipfs://cid/';
+    const c = await F.deploy(base, owner.address, 500);
+    await c.waitForDeployment();
+    await (await c.mint(alice.address, 1)).wait();
+    expect(await c.tokenURI(1)).to.eq(`${base}1.json`);
   });
 });
 ```
@@ -236,3 +240,6 @@ describe("MyNFT",()=>{
 - `MyNFT` と `FixedPriceMarket` のアドレス、Verifyリンク。
 - `tokenURI(1)` の戻り値と、IPFS Gatewayで開いたメタデータ/画像のスクリーンショット。
 - IPFSのCID、`1.json` の最終版。
+
+## 10. 実行例
+- 実行ログ例：[`reports/Day11.md`](../reports/Day11.md)

--- a/curriculum/Day12_Security.md
+++ b/curriculum/Day12_Security.md
@@ -234,3 +234,6 @@ forge test --match-contract Invariant -vvvv
 - Slitherレポート（主要警告の抜粋）と対応方針。
 - Invariantテストの結果スクリーンショット。
 - 監査チェックリストの自己評価（5項目以上）。
+
+## 9. 実行例
+- 実行ログ例：[`reports/Day12.md`](../reports/Day12.md)

--- a/curriculum/Day13_Gas_Optimization.md
+++ b/curriculum/Day13_Gas_Optimization.md
@@ -188,8 +188,8 @@ PRで差分をレビューできる。
 |------|--------:|
 | Naive.add |  
 | Packed.add |  
-| sumCalldata(1k) |  
-| sumMemory(1k) |  
+| sumCalldataTx(1k) |  
+| sumMemoryTx(1k) |  
 | e1 |  
 | e2 |  
 
@@ -213,3 +213,6 @@ PRで差分をレビューできる。
 - `metrics/gas_day13.md`（表を埋める）。
 - `hardhat test` 出力ログ（差分をコメント）。
 - 最適化の設計判断を3行で要約。
+
+## 10. 実行例
+- 実行ログ例：[`reports/Day13.md`](../reports/Day13.md)

--- a/curriculum/Day14_Integration.md
+++ b/curriculum/Day14_Integration.md
@@ -147,3 +147,6 @@ npx hardhat verify --network sepolia <EVENT_TOKEN_ADDR>
 - DApp の動作スクリーンショット
 - TxHash（送金・イベント発火の実績）
 - （任意）Verifyリンク / CI実行ログ / Subgraph buildログ
+
+## 9. 実行例
+- 実行ログ例：[`reports/Day14.md`](../reports/Day14.md)


### PR DESCRIPTION
Part4/5（Day11〜Day14）を中心に、書籍としての一貫性とつまずき対策を補強しました。\n\n- Day11: テストの参照ファイル名を実物（`test/mynft.ts`）に合わせて修正\n- Day12〜Day14: 章末に実行ログ（`reports/Day12.md`〜`reports/Day14.md`）へのリンクを追加\n- Appendix: Verify / CI / The Graph のつまずきポイントを追記（特に startBlock の取得はhex→10進変換を明記）\n\n- ローカル: `npm test` pass