### PR TITLE
docs: improve entry links (guide, reports)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Node.js 20 以上（npm 10+）を前提としています。
 ## 読み方（GitHub Pages）
 - 書籍（GitHub Pages）：https://itdojp.github.io/ethereum-learning-bootcamp/
 - シリーズ（IT Engineer Knowledge Architecture）：https://itdojp.github.io/it-engineer-knowledge-architecture/
+- 読み方ガイド：https://itdojp.github.io/ethereum-learning-bootcamp/curriculum/Guide/
 
 ## Quick Start
 ```bash

--- a/curriculum/README.md
+++ b/curriculum/README.md
@@ -4,6 +4,7 @@
 ゼロからプロジェクトを作る場合は Day3 を参考にする。
 
 読む順序は `curriculum/TOC.md` を参照する。
+目的別の進め方（学習ルート）は `curriculum/Guide.md` を参照する。
 
 ## 1. 作業ディレクトリ
 - ルートの `package.json` がある場所（このリポジトリ直下）で作業する。
@@ -36,3 +37,7 @@
 - ソース検証（Verify）：[`appendix/verify.md`](../appendix/verify.md)
 - GitHub Actions / CI：[`appendix/ci-github-actions.md`](../appendix/ci-github-actions.md)
 - The Graph（Subgraph Studio）：[`appendix/the-graph.md`](../appendix/the-graph.md)
+
+## 6. 実行ログ（期待される出力例）
+本文は環境差分で出力が変わり得る。迷ったら `reports/` の実行ログと突き合わせる。
+- 実行ログ一覧：[`reports/index.md`](../reports/index.md)


### PR DESCRIPTION
読み始めの導線を強化しました。

- `curriculum/README.md`: 読み方ガイド（`curriculum/Guide.md`）への導線を追加
- `curriculum/README.md`: 期待される出力例として `reports/` を参照する案内を追加
- `README.md`: GitHub Pagesの読み方ガイドへのリンクを追加

ローカル確認:
- `npm run check:links`
- `npm test`
