### PR TITLE
ci: build dapp in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,3 +17,19 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run check:links
+
+  dapp-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: dapp/package-lock.json
+      - name: Install (dapp)
+        working-directory: dapp
+        run: npm ci
+      - name: Build (dapp)
+        working-directory: dapp
+        run: npm run build

--- a/appendix/ci-github-actions.md
+++ b/appendix/ci-github-actions.md
@@ -7,6 +7,10 @@
 
 このリポジトリでは `.github/workflows/test.yml` を使う。
 
+### このリポジトリの実行内容（要点）
+- ルート：`npm ci` → `npm test` → `npm run check:links`
+- `dapp/`：`npm ci` → `npm run build`（フロントのビルド確認）
+
 ### よくある失敗
 - Node.js のバージョン違い：ローカルとCIで `node -v` が違うと落ちやすい。
 - `npm install` ではなく `npm ci`：CIは `npm ci` 前提のほうが再現性が高い。


### PR DESCRIPTION
フロントエンド（`dapp/`）もサンプルコードとして壊れていないことをCIで検証するようにしました。

- `.github/workflows/test.yml`: `dapp-build` ジョブを追加（`dapp/` で `npm ci` → `npm run build`）
- `appendix/ci-github-actions.md`: CIで何を実行しているか（ルート/`dapp/`）の要点を追記

ローカル確認:
- ルート: `npm run check:links` / `npm test`
- dapp: `cd dapp && npm ci && npm run build`
