### PR TITLE
docs: add update checklist and check:all script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Node.js 20 以上（npm 10+）を前提としています。
 - 書籍（GitHub Pages）：https://itdojp.github.io/ethereum-learning-bootcamp/
 - シリーズ（IT Engineer Knowledge Architecture）：https://itdojp.github.io/it-engineer-knowledge-architecture/
 - 読み方ガイド：https://itdojp.github.io/ethereum-learning-bootcamp/curriculum/Guide/
+- 更新履歴：https://itdojp.github.io/ethereum-learning-bootcamp/CHANGELOG/
 
 ## Quick Start
 ```bash
@@ -14,6 +15,7 @@ npm ci
 cp .env.example .env && edit .env
 npm test
 ```
+（まとめて確認する場合：`npm run check:all`）
 
 ## 参考リンク
 - Optimism Etherscan: https://optimistic.etherscan.io/

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -38,3 +38,9 @@
 - 可能な限り **相対パス**で貼る（GitHub 上でそのまま辿れる）
 - 読む順序（目次）は `curriculum/TOC.md` を正とする
 - CIで `npm run check:links` を実行し、教材内の相対リンク切れを検出する
+
+## 更新（version / changelog）
+- 公開ページの「現行バージョン」は `_config.yml` の `version` を更新して管理する
+- 変更の要点は `CHANGELOG.md` に追記する（読者が追従しやすくなる）
+- PR作成前に `npm run check:all` を実行し、教材の基本動作をまとめて確認する
+  - `check:all` は `npm test` / `npm run check:links` / `dapp` の build を実行する

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "test": "hardhat test",
     "coverage": "hardhat coverage",
     "check:links": "node tools/check-links.mjs",
+    "check:all": "npm test && npm run check:links && npm --prefix dapp ci && npm --prefix dapp run build",
+    "dapp:build": "npm --prefix dapp run build",
     "lint": "echo 'add linter if needed'",
     "deploy:sepolia": "hardhat run scripts/deploy-generic.ts --network sepolia"
   },


### PR DESCRIPTION
## 変更内容
- ローカルでCI相当をまとめて実行できる `npm run check:all` を追加しました（Hardhat test + リンクチェック + dapp build）。
- 更新の手順（`_config.yml` の `version` と `CHANGELOG.md` の更新）を `STYLEGUIDE.md` に追記しました。
- `README.md` から更新履歴（Changelog）へ辿れるようにしました。

## 動作確認
- `npm run check:all`
