### PR TITLE
docs: add minimal expected outputs

### DIFF
--- a/curriculum/Day03_Env_Setup.md
+++ b/curriculum/Day03_Env_Setup.md
@@ -70,10 +70,19 @@ cp .env.example .env
 ```bash
 npm test
 ```
+期待される出力（最小例）：
+```text
+16 passing
+```
+> 数字は追加テストで増減する。最後に `passing` が出ていればOK。
 
 4) Sepolia にデプロイする（例：MyToken）：
 ```bash
 npx hardhat run scripts/deploy-token.ts --network sepolia
+```
+期待される出力（最小例）：
+```text
+MTK: 0x...
 ```
 
 > Verifyで詰まったら [`appendix/verify.md`](../appendix/verify.md) を参照する。

--- a/curriculum/Day06_Local_Testing.md
+++ b/curriculum/Day06_Local_Testing.md
@@ -131,11 +131,14 @@ npx hardhat test
 
 # カバレッジ
 npx hardhat coverage --temp artifacts-coverage --network hardhat
-
-# 参考：出力例（概念）
-# GasBench: setS  ~42,000 gas
-# GasBench: emitMany(5)  ~50,000+ gas（イベント数に比例）
 ```
+
+期待される出力（最小例）：
+```text
+16 passing
+Toolchain: hardhat
+```
+> `passing` の件数は追加テストで増減する。gasReporter を有効化しているため、テスト完了時に関数単位のgas表（`Contracts / Methods`）が出力される。
 
 ---
 

--- a/curriculum/Day09_DApp_Frontend.md
+++ b/curriculum/Day09_DApp_Frontend.md
@@ -45,6 +45,11 @@ VITE_EVENT_TOKEN=          # 任意：Day10で使う
 ```bash
 npm run dev
 ```
+期待される出力（最小例）：
+```text
+Local:   http://localhost:5173/
+```
+> ポートが埋まっている場合は別ポートになる（表示されたURLを開く）。
 
 ブラウザで `http://localhost:5173` を開き、次の順で操作する：
 1) Connect Wallet  
@@ -58,6 +63,10 @@ npm run dev
 ### 2.1 Hardhat node を起動する
 ```bash
 npx hardhat node
+```
+期待される出力（最小例）：
+```text
+Started HTTP and WebSocket JSON-RPC server at http://127.0.0.1:8545/
 ```
 
 ### 2.2 MetaMask にローカルチェーンを追加する
@@ -78,6 +87,10 @@ cp .env.example .env
 デプロイ：
 ```bash
 npx hardhat run scripts/deploy-token.ts --network localhost
+```
+期待される出力（最小例）：
+```text
+MTK: 0x...
 ```
 
 出力された `MyToken` のアドレスを `dapp/.env.local` の `VITE_TOKEN_ADDRESS` に入れる。

--- a/curriculum/Day10_Events_TheGraph.md
+++ b/curriculum/Day10_Events_TheGraph.md
@@ -41,11 +41,19 @@
 ```bash
 npx hardhat run scripts/deploy-event-token.ts --network sepolia
 ```
+期待される出力（最小例）：
+```text
+EventToken: 0x...
+```
 出力されたアドレスを控える（`0x...`）。
 
 ### 2.2 イベント発火
 ```bash
 EVT=0x... npx hardhat run scripts/use-event-token.ts --network sepolia
+```
+期待される出力（最小例）：
+```text
+transfer complete { to: '0x...' }
 ```
 `TransferLogged` が複数回 `emit` される。
 

--- a/curriculum/Day14_Integration.md
+++ b/curriculum/Day14_Integration.md
@@ -49,6 +49,11 @@ cp .env.example .env
 npx hardhat run scripts/deploy-token.ts --network sepolia
 npx hardhat run scripts/deploy-event-token.ts --network sepolia
 ```
+期待される出力（最小例）：
+```text
+MTK: 0x...
+EventToken: 0x...
+```
 
 例：Optimism（任意）
 ```bash
@@ -89,12 +94,20 @@ cd dapp
 npm ci
 npm run dev
 ```
+期待される出力（最小例）：
+```text
+Local:   http://localhost:5173/
+```
 
 ブラウザで `http://localhost:5173` を開き、Connect Wallet → Switch to Chain → Refresh Balances を確認する。
 
 EventToken を操作してイベントを流したい場合：
 ```bash
 EVT=0x... npx hardhat run scripts/use-event-token.ts --network sepolia
+```
+期待される出力（最小例）：
+```text
+transfer complete { to: '0x...' }
 ```
 
 ---


### PR DESCRIPTION
## 概要
Issue #33 の「コマンドに“期待される出力の最小例”を添える」を、詰まりやすい章から先行対応しました。

## 変更内容
- Day3/6/9/10/14 に「期待される出力（最小例）」を追記し、成功/失敗の判定材料を増やしました。
  - テスト：`passing`
  - デプロイ：`MTK: 0x...` / `EventToken: 0x...`
  - DApp：`Local: http://localhost:5173/`
  - RPC：`Started HTTP and WebSocket JSON-RPC server ...`

## 動作確認
- `npm run check:all`

Related to #33
