### PR TITLE
docs: strengthen troubleshooting for Verify/CI/The Graph

### DIFF
--- a/docs/appendix/ci-github-actions.md
+++ b/docs/appendix/ci-github-actions.md
@@ -2,6 +2,17 @@
 
 このメモは、Day6/Day7 の CI を動かすときに詰まりやすい点をまとめる。
 
+## 0. 最短成功ルート（迷ったらここ）
+### 0.1 テストCI（PRで自動実行）
+1) ローカルで `npm run check:all` を通す（テスト + リンクチェック + dapp build）。  
+2) ブランチを push して PR を作る。  
+3) GitHub の Checks / Actions で `test` ワークフローが成功していることを確認する。  
+
+### 0.2 手動承認付きデプロイ（workflow_dispatch + Environment）
+1) Settings > Environments に `production` を作り、Required reviewers を設定する。  
+2) `production` の Environment Secrets に、RPC/鍵/APIキーを入れる（鍵はコミットしない）。  
+3) Actions タブから `deploy` を `Run workflow` で起動し、承認して完了させる。  
+
 ## 1. テストCI（PRで自動実行）
 目的：Pull Requestで `npm test` が自動で走り、手元との差分を早期に検出する。
 
@@ -15,7 +26,7 @@
 - Node.js のバージョン違い：ローカルとCIで `node -v` が違うと落ちやすい。
 - `npm install` ではなく `npm ci`：CIは `npm ci` 前提のほうが再現性が高い。
 
-### 失敗したときの最短デバッグ手順
+### 失敗時の切り分け（最短）
 1) GitHub の Actions タブ → 該当 Run → **落ちた Step のログ**を開く。  
 2) ローカルで **CIと同じ手順**を再現する（このrepoは Node.js 20 前提）：
 ```bash
@@ -48,5 +59,16 @@ npm test
 - CIからのデプロイでも、デプロイ用アドレスの残高が必要。
 - `insufficient funds` の場合は、対象チェーンにETHを用意する。
 
-## 3. Verifyは別メモへ
-- Verify周りは `appendix/verify.md` を参照する。
+## 3. よくあるエラー（症状→原因候補→確認→解決）
+| 症状 | 原因候補 | 確認 | 解決 |
+|---|---|---|---|
+| `npm ci` が落ちる | lockfile不整合 / 依存更新漏れ | `package.json` と `package-lock.json` の差分 | lockfile を更新してコミット |
+| `check:links` が落ちる | 相対リンク切れ | ログに出た `file:line` のリンクを確認 | Markdownのリンク先を修正 |
+| `dapp-build` が落ちる | `dapp/` 側の依存・型・ビルドエラー | `npm --prefix dapp ci && npm --prefix dapp run build` | エラー箇所を修正して再実行 |
+| ローカルは通るがCIだけ落ちる | Node.js差分 / 実行手順差分 | CIログの `node -v` とローカルを比較 | Node.js 20 に揃え、CIと同じ手順で再現する |
+| 承認が出ない | Environment設定不足 | Settings > Environments の `production` | Required reviewers を設定する |
+| Secretsが読めない | Secretsの置き場所/名前不一致 | Environment Secrets と変数名 | `hardhat.config.ts` と同じ名前でSecretsを置く |
+| `insufficient funds` | デプロイ用残高不足 | 対象チェーンで残高確認 | 少額ETHを用意して再実行 |
+
+## 4. Verifyは別メモへ
+- Verify周りは [`docs/appendix/verify.md`](./verify.md) を参照する。

--- a/docs/appendix/the-graph.md
+++ b/docs/appendix/the-graph.md
@@ -6,14 +6,25 @@
 - Solidity のイベントを The Graph がインデックス化し、GraphQLで履歴を取得できるようにする。
 - オンチェーンの状態を全件スキャンするより、UIや分析で扱いやすい。
 
-## 2. 前提
+## 2. 最短成功ルート（Subgraph Studio）
+最短は「対象コントラクトを決める → startBlockを決める → build する → Studioで反映を待つ」の順だ。
+
+1) 対象コントラクト（例：Day10 の `EventToken`）をデプロイし、イベントが出る状態にする  
+2) `graph init` でひな形を作る  
+3) `startBlock` に **デプロイTxのブロック番号** を入れる  
+4) `graph codegen` / `graph build` を通す  
+5) Studio の手順でデプロイし、反映を待ってから GraphQL で取得する  
+
+> 外部サービス（Studio/Indexer）依存のため、反映に時間がかかることがある（環境依存）。「デプロイできているか」「イベントが出ているか」を先に確認してから待つと切り分けが速い。
+
+## 3. 前提
 - Node.js（推奨：20）
 - `graph-cli`（インストール方法は環境により異なる）
   - 例：`npm i -g @graphprotocol/graph-cli`
   - 権限エラーが出る場合は、npx で代替できることがある（例：`npx @graphprotocol/graph-cli --version`）。
 
-## 3. つまずきポイント
-### 3.1 `startBlock` が分からない
+## 4. 失敗時の切り分け（つまずきポイント）
+### 4.1 `startBlock` が分からない
 - `startBlock` は「このブロック以降だけ見る」というフィルタ。古すぎると同期が遅い。
 - 目安：**デプロイTxのブロック番号** を入れる。
 
@@ -39,14 +50,23 @@ printf '%d\n' "$BN_HEX"
 ```
 > `.result` が `null` の場合は、Txが未確定か、RPC/TxHash/チェーンが違う可能性がある。時間を置くか再確認する。
 
-### 3.2 `graph codegen` / `graph build` が失敗する
+### 4.2 `graph codegen` / `graph build` が失敗する
 - ABI とイベント定義、`schema.graphql` の型が不一致だと失敗しやすい。
 - `schema.graphql` を変えたら `graph codegen` をやり直す。
 
-### 3.3 反映が遅い / データが出ない
+### 4.3 反映が遅い / データが出ない
 - `startBlock` が新しすぎるとイベントを取り逃がす。
-- コントラクトアドレスが間違っていると、そもそも何も取れない。
+- コントラクトアドレスやチェーンが間違っていると、そもそも何も取れない。
+- 反映待ちの場合は、時間を置いて再確認する（環境依存）。
 
-## 4. ディレクトリの置き場所
-- 本リポジトリでは `subgraph/` 配下に生成する運用を推奨する（例：`subgraph/event-token`）。
-- 詳細は `subgraph/README.md` を参照する。
+## 5. よくあるエラー（症状→原因候補→確認→解決）
+| 症状 | 原因候補 | 確認 | 解決 |
+|---|---|---|---|
+| `startBlock` が分からない | デプロイTxのブロック番号が未取得 | Txレシートの `blockNumber` を確認 | 4.1 の手順で取得して設定する |
+| build は通るがデータが出ない | `startBlock`/アドレス/チェーン不一致 | コントラクトアドレスとチェーンIDを再確認 | 正しい組み合わせに直す（必要なら `startBlock` を見直す） |
+| `graph codegen` / `graph build` が落ちる | ABI/スキーマ不一致 | どの型/イベントで落ちているか | ABI と `schema.graphql` を揃え、codegen→build をやり直す |
+| Studio にデプロイしたが反映が遅い | インデックス待ち | イベントが実際に出ているか | 先にイベント発火を確認し、時間を置いて再確認する |
+
+## 6. ディレクトリの置き場所
+- 本リポジトリでは、リポジトリルートに `subgraph/`（生成物）を作って進める運用を推奨する（例：`subgraph/event-token`）。
+- 本リポジトリは生成物を同梱しない。作り方のガイドは [`docs/subgraph/README.md`](../subgraph/README.md) を参照する。

--- a/docs/appendix/verify.md
+++ b/docs/appendix/verify.md
@@ -6,50 +6,44 @@
 - エクスプローラ上で「ソースコード ⇔ デプロイ済みバイトコード」を対応付ける作業。
 - Verifyすると、UI上でABIが読みやすくなり、Read/Write（読み取り/書き込み）画面が使いやすくなる。
 
-## 2. 最短手順（Hardhat）
+## 2. 最短成功ルート（Hardhat）
 1) `.env` を用意する（例：`cp .env.example .env`）。  
 2) コンパイルする：`npx hardhat compile`  
 3) Verifyする：`npx hardhat verify --network <network> <address> <constructor args...>`
 
-## 3. このリポジトリの環境変数
+> デプロイした直後は、エクスプローラ側の反映が遅れることがある（環境依存）。その場合は時間を置いて再実行する。
+
+## 3. 失敗時の切り分けルート（最小）
+Verifyが失敗したときは、まず「どこがズレているか」を上から潰す。
+
+1) `--network` はデプロイ先と一致しているか  
+2) `<address>` はデプロイしたコントラクトのアドレスか  
+3) APIキーは `.env` に入っているか（空ではないか）  
+4) コンストラクタ引数は「順序・型・値」が一致しているか  
+5) コンパイラ設定（Solidity/optimizer/viaIR など）はデプロイ時と一致しているか  
+6) デプロイ直後で、エクスプローラの反映待ちになっていないか  
+
+このリポジトリでは、デプロイ時の引数や設定を [`docs/DEPLOYMENTS.md`](../DEPLOYMENTS.md) に残す運用を推奨する（Verifyで迷子になりにくい）。
+
+## 4. このリポジトリの環境変数
 - RPC：
   - `SEPOLIA_RPC_URL`, `MAINNET_RPC_URL`, `OPTIMISM_RPC_URL`
 - APIキー：
   - Ethereum（mainnet / Sepolia）：`ETHERSCAN_API_KEY`
   - Optimism：`OPTIMISTIC_ETHERSCAN_API_KEY`
 
-## 4. つまずきポイント（よくある順）
-### 4.1 ネットワークを間違える
-- `--network` と、実際にデプロイしたチェーンが一致していることを確認する。
+## 5. よくあるエラー（症状→原因候補→確認→解決）
+| 症状 | 原因候補 | 確認 | 解決 |
+|---|---|---|---|
+| `--network` を変えても通らない | ネットワーク不一致 | デプロイ先と `--network` が一致しているか | デプロイ先のネットワークに合わせて再実行 |
+| API key が必要と言われる / 失敗する | APIキー未設定 / 空 | `.env` に `ETHERSCAN_API_KEY`（または `OPTIMISTIC_ETHERSCAN_API_KEY`）が入っているか | `.env` にキーを入れて再実行（鍵はコミットしない） |
+| `constructor arguments` が原因っぽい | 引数の不一致 | デプロイ時の引数（順序/型/値）を確認 | デプロイ時と同じ引数で Verify（文字列はクォートが必要なことがある） |
+| 設定が合っているはずなのに通らない | コンパイラ設定の不一致 | `hardhat.config.ts` の `solidity` / optimizer / `viaIR` を確認 | デプロイ時と同じ設定に揃えて再実行（デプロイ後に設定を変えた場合は要注意） |
+| デプロイ直後に通らない / エクスプローラで見つからない | 反映遅延（取り込み待ち） | エクスプローラ側でTxやアドレスが見えるか | 時間を置いて再実行（混雑やサービス状況に依存） |
+| すでにVerify済みと言われる | すでにVerify済み | エクスプローラでソース表示できるか | ソースが表示できるなら実害なし（必要なら別アドレスで検証） |
+| 1ファイルに複数コントラクトがあり失敗する | 対象コントラクトの指定が曖昧 | Verify対象のコントラクト名を確認 | `--contract contracts/Path.sol:ContractName` で fully qualified name を指定 |
 
-### 4.2 APIキーが未設定 / 空
-- `.env` の `ETHERSCAN_API_KEY`（または `OPTIMISTIC_ETHERSCAN_API_KEY`）が空だとVerifyできない。
-- `hardhat.config.ts` は `dotenv` を読むため、まず `.env` が存在することも確認する。
-
-### 4.3 コンストラクタ引数の不一致
-- もっとも多い原因。**引数の順序・型・値**が一致しないとVerifyが通らない。
-- 文字列（例：`ipfs://.../`）はクォートが必要なことがある：
-  - 例：`"ipfs://<CID>/"`（空白を含む場合は必須）
-- デプロイ時の引数を [`DEPLOYMENTS.md`](../DEPLOYMENTS.md) やデプロイログに残しておくと再現しやすい。
-
-### 4.4 コンパイラ設定の不一致
-- `solidity` バージョン、optimizer（`runs`）、`viaIR` などがデプロイ時と一致しないと通らない。
-- “デプロイ後に `hardhat.config.ts` を変えた”場合は特に注意する。
-
-### 4.5 反映遅延（インデックス待ち）
-- デプロイ直後は、エクスプローラ側の取り込みが追いつかないことがある。
-- 少し待ってから再実行する。
-
-### 4.6 すでにVerify済み
-- すでにVerify済みの場合、エラー表示になることがある。
-- エクスプローラ側でソースが表示できるなら実害はない。
-
-### 4.7 同じファイルに複数コントラクトがある
-- 1ファイル内に複数コントラクトがある場合、Verify対象の指定が曖昧になって失敗することがある。
-- Hardhat Verify は `--contract` で fully qualified name（`path:ContractName`）を指定できる。
-  - 例：`npx hardhat verify --network sepolia --contract contracts/GasPack.sol:GasPacked <ADDRESS>`
-
-## 5. 補足：L2 / Blockscout
+## 6. 補足：L2 / Blockscout
 - L2はエクスプローラがEtherscan系とは限らない（Blockscout等）。
 - その場合、`hardhat.config.ts` の `customChains` 設定が必要になることがある。
 - 本リポジトリは Optimism を例として設定している。他チェーンは必要に応じて更新する。

--- a/docs/curriculum/Day06_Local_Testing.md
+++ b/docs/curriculum/Day06_Local_Testing.md
@@ -206,7 +206,7 @@ jobs:
 |---|---|---|
 | gasReporter に出ない / 差が見えない | `pure/view` が call 扱いになり、Txとして計測されていない | 章中の `bench*` のように Tx 化して測る |
 | `hardhat coverage` が落ちる/遅い | 依存不整合、または環境依存（Node.js差分等） | まず `npm ci` で揃え、Node.js 20 で再実行する |
-| CIでだけ落ちる | ローカルとCIの差分 | 付録 [`appendix/ci-github-actions.md`](../appendix/ci-github-actions.md) の「最短デバッグ手順」を参照する |
+| CIでだけ落ちる | ローカルとCIの差分 | 付録 [`docs/appendix/ci-github-actions.md`](../appendix/ci-github-actions.md) の「失敗時の切り分け（最短）」を参照する |
 
 ---
 

--- a/docs/curriculum/Day07_Deploy_CI.md
+++ b/docs/curriculum/Day07_Deploy_CI.md
@@ -14,7 +14,7 @@
 ## 0. 前提
 - Hardhat構成はDay3までに完了。
 - `.env`に鍵とRPCを設定し、**秘密情報はGitにコミットしない**。
-- 先に読む付録：[`appendix/verify.md`](../appendix/verify.md) / [`appendix/ci-github-actions.md`](../appendix/ci-github-actions.md)
+- 先に読む付録：[`docs/appendix/verify.md`](../appendix/verify.md) / [`docs/appendix/ci-github-actions.md`](../appendix/ci-github-actions.md)
 - 触るファイル（主なもの）：`scripts/deploy-generic.ts` / `.github/workflows/deploy.yml` / `docs/DEPLOYMENTS.md` / `hardhat.config.ts`（任意）
 - 今回触らないこと：いきなり多額で本番デプロイ（まずは少額・段階的に進める）
 - 最短手順（迷ったらここ）：1章の `deploy-generic.ts` で少額デプロイ → 2章でVerify（任意）→ 4章で手動承認付きCIの要点を確認
@@ -74,7 +74,7 @@ npx hardhat verify --network mainnet <DEPLOYED_ADDR> 3600
 ```bash
 npx hardhat verify --network optimism <DEPLOYED_ADDR> 1000000000000000000000000
 ```
-> L2ごとにAPIキーが異なる。[Blockscout](../appendix/glossary.md)系エクスプローラを使うチェーンでは別途設定が必要。つまずいたら [`appendix/verify.md`](../appendix/verify.md) を参照する。
+> L2ごとにAPIキーが異なる。[Blockscout](../appendix/glossary.md)系エクスプローラを使うチェーンでは別途設定が必要。つまずいたら [`docs/appendix/verify.md`](../appendix/verify.md) の「最短成功ルート」→「失敗時の切り分けルート」→「よくあるエラー表」を参照する。
 
 ---
 
@@ -108,7 +108,7 @@ GitHub > Settings > Environments > `production` を作成し、**Required review
 - `environment: production` により、実行前にGitHub上での**人間承認**が必須になる。
 - Secrets を `hardhat.config.ts` が参照する環境変数名（`MAINNET_RPC_URL` / `OPTIMISM_RPC_URL` など）に揃えて渡す。
 
-> 承認が出ない／Secretsが読めない等で詰まったら [`appendix/ci-github-actions.md`](../appendix/ci-github-actions.md) を参照する。
+> 承認が出ない／Secretsが読めない等で詰まったら [`docs/appendix/ci-github-actions.md`](../appendix/ci-github-actions.md) の「最短成功ルート」→「失敗時の切り分け」→「よくあるエラー表」を参照する。
 
 ---
 
@@ -143,8 +143,8 @@ GitHub > Settings > Environments > `production` を作成し、**Required review
 |---|---|---|
 | `insufficient funds` | 手数料不足 | 少額ETHを補充。maxFee確認 |
 | `nonce too low` | ノンス衝突 | `--network`とアカウントの送信履歴を確認 |
-| Verify失敗 | コンパイラ設定不一致/引数違い | `hardhat.config.ts`の設定と引数を合わせる。詰まったら [`appendix/verify.md`](../appendix/verify.md) |
-| 承認が出ない | Environment reviewers未設定 | Settings > Environments を再確認。詰まったら [`appendix/ci-github-actions.md`](../appendix/ci-github-actions.md) |
+| Verify失敗 | コンパイラ設定不一致/引数違い | `hardhat.config.ts`の設定と引数を合わせる。詰まったら [`docs/appendix/verify.md`](../appendix/verify.md) |
+| 承認が出ない | Environment reviewers未設定 | Settings > Environments を再確認。詰まったら [`docs/appendix/ci-github-actions.md`](../appendix/ci-github-actions.md) |
 
 ---
 

--- a/docs/curriculum/Day10_Events_TheGraph.md
+++ b/docs/curriculum/Day10_Events_TheGraph.md
@@ -14,8 +14,8 @@
 ## 0. 前提
 - Day9 の `dapp/` を起動できる。
 - `EventToken` を任意ネットワークへデプロイできる（ローカル/テストネット/L2のどれでもよい）。
-- The Graph で詰まりやすい点は [`appendix/the-graph.md`](../appendix/the-graph.md) を参照する。
-- 先に読む付録：[`appendix/the-graph.md`](../appendix/the-graph.md) / [`appendix/glossary.md`](../appendix/glossary.md)
+- The Graph で詰まりやすい点は [`docs/appendix/the-graph.md`](../appendix/the-graph.md) の「最短成功ルート」→「失敗時の切り分け」→「よくあるエラー表」を参照する。
+- 先に読む付録：[`docs/appendix/the-graph.md`](../appendix/the-graph.md) / [`appendix/glossary.md`](../appendix/glossary.md)
 - 触るファイル（主なもの）：`contracts/EventToken.sol` / `scripts/deploy-event-token.ts` / `scripts/use-event-token.ts` / `dapp/src/hooks/useEvents.ts`
 - 今回触らないこと：本番運用のインデックス設計（まずは“作って動かす”）
 - 最短手順（迷ったらここ）：2章でイベント発火 → 3章でdapp購読表示 →（任意）4章でThe Graphのひな形生成
@@ -99,7 +99,7 @@ graph init \
 ### 4.2 startBlock を入れる
 `startBlock` は「このブロック以降だけを見る」という範囲指定。**デプロイTxのブロック番号** を入れるのが基本。
 
-取得例やつまずきは [`appendix/the-graph.md`](../appendix/the-graph.md) を参照する。
+取得例やつまずきは [`docs/appendix/the-graph.md`](../appendix/the-graph.md) を参照する。
 
 ### 4.3 codegen / build
 ```bash
@@ -114,8 +114,8 @@ graph build
 ---
 
 ## 5. つまずきポイント
-- startBlock が分からない / 遅すぎる：[`appendix/the-graph.md`](../appendix/the-graph.md)
-- build が落ちる（ABI/スキーマ不一致）：[`appendix/the-graph.md`](../appendix/the-graph.md)
+- startBlock が分からない / 遅すぎる：[`docs/appendix/the-graph.md`](../appendix/the-graph.md)
+- build が落ちる（ABI/スキーマ不一致）：[`docs/appendix/the-graph.md`](../appendix/the-graph.md)
 - ブラウザ購読が発火しない：チェーンID、コントラクトアドレス、イベント定義（`TransferLogged`）を確認する
 
 ---

--- a/docs/curriculum/Day14_Integration.md
+++ b/docs/curriculum/Day14_Integration.md
@@ -12,7 +12,7 @@
 ---
 
 ## 0. 前提
-- 先に読む付録：[`appendix/verify.md`](../appendix/verify.md) / [`appendix/ci-github-actions.md`](../appendix/ci-github-actions.md) / [`appendix/the-graph.md`](../appendix/the-graph.md)
+- 先に読む付録：[`docs/appendix/verify.md`](../appendix/verify.md) / [`docs/appendix/ci-github-actions.md`](../appendix/ci-github-actions.md) / [`docs/appendix/the-graph.md`](../appendix/the-graph.md)
 - 触るファイル（主なもの）：`.env` / `scripts/deploy-token.ts` / `scripts/deploy-event-token.ts` / `dapp/.env.local` / `docs/DEPLOYMENTS.md`
 - 今回触らないこと：最初から全部を完璧に通すこと（任意項目は“必要になったら”でよい）
 - 最短手順（迷ったらここ）：2.1 で `.env` → 2.2 でデプロイ → 3.1 で `dapp/.env.local` → 3.2 で起動・接続
@@ -128,7 +128,7 @@ npx hardhat verify --network sepolia <TOKEN_ADDR> 1000000000000000000000000
 npx hardhat verify --network sepolia <EVENT_TOKEN_ADDR>
 ```
 
-> つまずきやすいのは「引数不一致」「コンパイラ設定不一致」「反映待ち」。[`appendix/verify.md`](../appendix/verify.md) を参照する。
+> つまずきやすいのは「引数不一致」「コンパイラ設定不一致」「反映待ち」。[`docs/appendix/verify.md`](../appendix/verify.md) の「失敗時の切り分けルート」→「よくあるエラー表」を参照する。
 
 ---
 
@@ -136,12 +136,12 @@ npx hardhat verify --network sepolia <EVENT_TOKEN_ADDR>
 - テストCI：`.github/workflows/test.yml`（`npm test` を自動実行）
 - 手動承認付きデプロイ：`.github/workflows/deploy.yml`（workflow_dispatch + Environment）
 
-運用・つまずきは [`appendix/ci-github-actions.md`](../appendix/ci-github-actions.md) と Day7 を参照する。
+運用・つまずきは [`docs/appendix/ci-github-actions.md`](../appendix/ci-github-actions.md) と Day7 を参照する。
 
 ---
 
 ## 6. フェーズ5：The Graph（任意）
-サブグラフの生成・運用は [`docs/subgraph/README.md`](../subgraph/README.md) と [`appendix/the-graph.md`](../appendix/the-graph.md) を参照する。
+サブグラフの生成・運用は [`docs/subgraph/README.md`](../subgraph/README.md) と [`docs/appendix/the-graph.md`](../appendix/the-graph.md) を参照する。
 
 最小は Day10 と同様に「EventToken を対象」にするのが分かりやすい。
 
@@ -162,9 +162,9 @@ npx hardhat verify --network sepolia <EVENT_TOKEN_ADDR>
 | 症状 | 原因 | 対処 |
 |---|---|---|
 | DApp が動かない / 残高が出ない | chainId とアドレスが不一致 | `dapp/.env.local` と MetaMask のチェーンを揃え、アドレスを再確認する |
-| Verifyが通らない | APIキー/引数/設定不一致、反映待ち | [`appendix/verify.md`](../appendix/verify.md) を参照し、引数と設定を合わせる |
-| 手動デプロイの承認が出ない | Environment設定・Secretsの場所違い | [`appendix/ci-github-actions.md`](../appendix/ci-github-actions.md) を参照して確認する |
-| サブグラフが同期しない | `startBlock`/アドレス不一致 | [`appendix/the-graph.md`](../appendix/the-graph.md) を参照して確認する |
+| Verifyが通らない | APIキー/引数/設定不一致、反映待ち | [`docs/appendix/verify.md`](../appendix/verify.md) を参照し、引数と設定を合わせる |
+| 手動デプロイの承認が出ない | Environment設定・Secretsの場所違い | [`docs/appendix/ci-github-actions.md`](../appendix/ci-github-actions.md) を参照して確認する |
+| サブグラフが同期しない | `startBlock`/アドレス不一致 | [`docs/appendix/the-graph.md`](../appendix/the-graph.md) を参照して確認する |
 
 ---
 

--- a/docs/subgraph/README.md
+++ b/docs/subgraph/README.md
@@ -1,7 +1,8 @@
 # subgraph/ について
 
-このディレクトリは The Graph のサブグラフ（Subgraph Studio）用に使う。
-本リポジトリには生成物を同梱していないため、必要に応じて `graph init` で作成する。
+このページは、リポジトリルートに作る `subgraph/`（The Graph の生成物）について説明する。
+`docs/subgraph/` はGitHub Pages用の説明ページであり、生成物は本リポジトリには同梱していない。
+必要に応じて `graph init` で作成して進める。
 
 ## 推奨構成
 - `subgraph/event-token/`：Day10 の EventToken を対象にしたサブグラフ
@@ -16,5 +17,4 @@ graph init \
   subgraph/event-token
 ```
 
-> メモ：生成物の内容やコマンドのオプションは更新されることがある。公式ドキュメントと `appendix/the-graph.md` を参照する。
-
+> メモ：生成物の内容やコマンドのオプションは更新されることがある。公式ドキュメントと [`docs/appendix/the-graph.md`](../appendix/the-graph.md) を参照する。


### PR DESCRIPTION
## 概要
Issue #33 の「つまずきポイント強化（Verify/CI/The Graph）」を進める。

- 付録に「最短成功ルート」「失敗時の切り分け」「症状→原因候補→確認→解決（表）」を追加
- 章側から付録へ誘導する文言を、読む順番が分かる形に更新

## 変更点
- Verify: `docs/appendix/verify.md`
- CI(GitHub Actions): `docs/appendix/ci-github-actions.md`
- The Graph: `docs/appendix/the-graph.md`
- Subgraph ガイド: `docs/subgraph/README.md`（`docs/subgraph/` は説明ページ、生成物は repo ルート `subgraph/` に作ることを明確化）
- 章の導線: Day06/Day07/Day10/Day14

## テスト
- `npm run check:all`

Refs: #33
