### PR TITLE
docs: link mini-project from home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,9 +24,10 @@ permalink: /
 
 ## 進め方（最短ルート）
 1. 共通の前提を読む：[`curriculum/README.md`]({{ '/curriculum/README/' | relative_url }})
-1. 読み方ガイド：[`curriculum/Guide.md`]({{ '/curriculum/Guide/' | relative_url }})
-2. 用語に迷ったら：[`appendix/glossary.md`]({{ '/appendix/glossary/' | relative_url }})
-3. 目次どおりに進める：[`curriculum/TOC.md`]({{ '/curriculum/TOC/' | relative_url }})
+2. 通しで作るもの（ミニプロジェクト）：[`curriculum/Project.md`]({{ '/curriculum/Project/' | relative_url }})
+3. 読み方ガイド：[`curriculum/Guide.md`]({{ '/curriculum/Guide/' | relative_url }})
+4. 用語に迷ったら：[`appendix/glossary.md`]({{ '/appendix/glossary/' | relative_url }})
+5. 目次どおりに進める：[`curriculum/TOC.md`]({{ '/curriculum/TOC/' | relative_url }})
 
 ## Quick Start（ローカル検証）
 ```bash
@@ -37,6 +38,7 @@ npm test
 
 ## 目次（読む順序）
 - まずは Day1 から：[`curriculum/Day01_Ethereum_Intro.md`]({{ '/curriculum/Day01_Ethereum_Intro/' | relative_url }})
+- 通しで作るもの（ミニプロジェクト）：[`curriculum/Project.md`]({{ '/curriculum/Project/' | relative_url }})
 - 全体の目次：[`curriculum/TOC.md`]({{ '/curriculum/TOC/' | relative_url }})
 
 ## つまずきポイント（先に読む）


### PR DESCRIPTION
## 概要
GitHub Pages のホームから「ミニプロジェクト（通しで作るもの）」へ辿れる導線を追加し、最短ルートの見通しを良くした。

## 変更点
- `docs/index.md`
  - 「進め方（最短ルート）」にミニプロジェクトを追加
  - 目次セクションにもミニプロジェクトへのリンクを追加

## テスト
- `npm run check:all`
