### PR TITLE
docs(curriculum): link mini-project context in key days

### DIFF
--- a/docs/curriculum/Day05_ERC_Standards.md
+++ b/docs/curriculum/Day05_ERC_Standards.md
@@ -22,6 +22,7 @@
   - （任意）`scripts/token-transfer.ts` / `scripts/token-approve.ts`
 - 今回触らないこと：すべてのERC派生規格の網羅（まずはERC‑20/721の最小フローに集中）
 - 最短手順（迷ったらここ）：ERC‑20（2章）→ ERC‑721（3章）→ `npm test` で動作確認（Verifyは4章で任意）
+- ミニプロジェクト（通しで作るもの）：この章の `MyToken` は Day9/Day14 の DApp 接続で使う（全体像：[`docs/curriculum/Project.md`](./Project.md)）
 
 ---
 

--- a/docs/curriculum/Day09_DApp_Frontend.md
+++ b/docs/curriculum/Day09_DApp_Frontend.md
@@ -15,6 +15,7 @@
 - フロントエンドは `dapp/` に同梱してある（新規作成不要）。
 - Day5 で `MyToken` をデプロイして、アドレスを控えている。
 - ブラウザにMetaMask等のウォレット拡張が入っている。
+- ミニプロジェクト（通しで作るもの）：Day14 を“完成”としてつなぐ（全体像：[`docs/curriculum/Project.md`](./Project.md)）
 - 先に読む付録：[`appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
 - 触るファイル（主なもの）：`dapp/.env.local` / `dapp/src/App.tsx` / `dapp/src/lib/web3.ts`
 - 今回触らないこと：UI/UXの作り込み（接続と切り分けが主題）

--- a/docs/curriculum/Day10_Events_TheGraph.md
+++ b/docs/curriculum/Day10_Events_TheGraph.md
@@ -14,6 +14,7 @@
 ## 0. 前提
 - Day9 の `dapp/` を起動できる。
 - `EventToken` を任意ネットワークへデプロイできる（ローカル/テストネット/L2のどれでもよい）。
+- ミニプロジェクト（通しで作るもの）：`EventToken` は Day14 の統合でも使う（全体像：[`docs/curriculum/Project.md`](./Project.md)）
 - The Graph で詰まりやすい点は [`docs/appendix/the-graph.md`](../appendix/the-graph.md) の「最短成功ルート」→「失敗時の切り分け」→「よくあるエラー表」を参照する。
 - 先に読む付録：[`docs/appendix/the-graph.md`](../appendix/the-graph.md) / [`appendix/glossary.md`](../appendix/glossary.md)
 - 触るファイル（主なもの）：`contracts/EventToken.sol` / `scripts/deploy-event-token.ts` / `scripts/use-event-token.ts` / `dapp/src/hooks/useEvents.ts`


### PR DESCRIPTION
## 概要
ミニプロジェクト（Day14 を“完成”として通す導線）を、章側からも迷わず辿れるように補強する。

## 変更点
- `docs/curriculum/Day05_ERC_Standards.md`
- `docs/curriculum/Day09_DApp_Frontend.md`
- `docs/curriculum/Day10_Events_TheGraph.md`

各章の「前提/最短手順」付近に、`docs/curriculum/Project.md` への参照を1行追加した。

## テスト
- `npm run check:all`
