### PR TITLE
docs: unify appendix link labels

### DIFF
--- a/docs/appendix/Appendix_Resources.md
+++ b/docs/appendix/Appendix_Resources.md
@@ -1,10 +1,10 @@
 # Ethereumカリキュラム補足資料集（Appendix）
 
 ## 0. 本リポジトリ内の補足
-- Verify（ソース検証）：`appendix/verify.md`
-- GitHub Actions / CI：`appendix/ci-github-actions.md`
-- The Graph（Subgraph Studio）：`appendix/the-graph.md`
-- AA（ERC‑4337 / EIP‑7702）：`appendix/account-abstraction.md`
+- Verify（ソース検証）：`docs/appendix/verify.md`
+- GitHub Actions / CI：`docs/appendix/ci-github-actions.md`
+- The Graph（Subgraph Studio）：`docs/appendix/the-graph.md`
+- AA（ERC‑4337 / EIP‑7702）：`docs/appendix/account-abstraction.md`
 
 ## A. 推奨学習リソース
 

--- a/docs/appendix/index.md
+++ b/docs/appendix/index.md
@@ -9,12 +9,11 @@ description: "つまずきやすいポイントの補足と用語集"
 本文（Day01〜Day14）を進める中で、詰まりやすい所・後から参照したい所をまとめた。
 
 ## よく参照する付録
-- 用語集：[`appendix/glossary.md`]({{ '/appendix/glossary/' | relative_url }})
-- Verify：[`appendix/verify.md`]({{ '/appendix/verify/' | relative_url }})
-- GitHub Actions / CI：[`appendix/ci-github-actions.md`]({{ '/appendix/ci-github-actions/' | relative_url }})
-- The Graph：[`appendix/the-graph.md`]({{ '/appendix/the-graph/' | relative_url }})
-- Account Abstraction（ERC‑4337 / EIP‑7702）：[`appendix/account-abstraction.md`]({{ '/appendix/account-abstraction/' | relative_url }})
+- 用語集：[`docs/appendix/glossary.md`]({{ '/appendix/glossary/' | relative_url }})
+- Verify：[`docs/appendix/verify.md`]({{ '/appendix/verify/' | relative_url }})
+- GitHub Actions / CI：[`docs/appendix/ci-github-actions.md`]({{ '/appendix/ci-github-actions/' | relative_url }})
+- The Graph：[`docs/appendix/the-graph.md`]({{ '/appendix/the-graph/' | relative_url }})
+- Account Abstraction（ERC‑4337 / EIP‑7702）：[`docs/appendix/account-abstraction.md`]({{ '/appendix/account-abstraction/' | relative_url }})
 
 ## 参考
-- リソース集：[`appendix/Appendix_Resources.md`]({{ '/appendix/Appendix_Resources/' | relative_url }})
-
+- リソース集：[`docs/appendix/Appendix_Resources.md`]({{ '/appendix/Appendix_Resources/' | relative_url }})

--- a/docs/curriculum/Day01_Ethereum_Intro.md
+++ b/docs/curriculum/Day01_Ethereum_Intro.md
@@ -15,7 +15,7 @@
 - 必要コマンド：`curl`, `jq`
 - 必要なもの：Sepolia などの RPC エンドポイント（Alchemy/Infura 等）
 - この章は **Tx を送らない**。テストETHは不要だ。
-- 先に読む付録：[`appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
+- 先に読む付録：[`docs/appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
 - 触るファイル（主なもの）：（任意）`REPORT.md`
 - 今回触らないこと：秘密鍵で署名してTxを送る／コントラクトのデプロイ（Day3以降で扱う）
 - 最短手順（迷ったらここ）：RPCを `RPC` に設定 → 2.3 でブロック番号 → 2.4 でブロック詳細 → 2.5 で3ブロック比較
@@ -37,7 +37,7 @@
   - 状態はMerkle-Patricia Trie（MPT）で管理される。
 - **アカウントの種類**：
   - [EOA](../appendix/glossary.md)（Externally Owned Account）：人間が秘密鍵で操作。
-    - 補足：従来は「EOAはコードを持たない」と説明されることが多いが、**EIP‑7702** によりEOAが **[delegation indicator](../appendix/glossary.md)（委任先）** をセットして、実行時に別アドレスのコードへ委譲する挙動が入り得る。初心者は「EOA＝常に code empty」と固定観念にしないこと（概要は [`appendix/account-abstraction.md`](../appendix/account-abstraction.md)）。
+    - 補足：従来は「EOAはコードを持たない」と説明されることが多いが、**EIP‑7702** によりEOAが **[delegation indicator](../appendix/glossary.md)（委任先）** をセットして、実行時に別アドレスのコードへ委譲する挙動が入り得る。初心者は「EOA＝常に code empty」と固定観念にしないこと（概要は [`docs/appendix/account-abstraction.md`](../appendix/account-abstraction.md)）。
   - コントラクトアカウント：コードを持ち、EVM上で実行される。
 
 ### 1.3 Proof of Stake (PoS) の仕組み

--- a/docs/curriculum/Day02_Transaction_Gas.md
+++ b/docs/curriculum/Day02_Transaction_Gas.md
@@ -13,7 +13,7 @@
 ## 0. 前提
 - Day1 で `RPC` を設定済み（2.5 の CLI パートで使う）
 - Remix IDE を使う場合はブラウザで操作する（ウォレット連携は環境により異なる）
-- 先に読む付録：[`appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
+- 先に読む付録：[`docs/appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
 - 触るファイル（主なもの）：（任意）`REPORT.md`
 - 今回触らないこと：ガス最適化の細部（Day13）／ガス計測の実装（Day6）
 - 最短手順（迷ったらここ）：2.2 でコントラクト作成 → 2.3 で `store/add` の違い確認 → 2.4 でEtherscan解析（2.5は任意）

--- a/docs/curriculum/Day03_Env_Setup.md
+++ b/docs/curriculum/Day03_Env_Setup.md
@@ -219,7 +219,7 @@ Lock deployed to: 0xF1234...7890
 1. [Sepolia Etherscan](https://sepolia.etherscan.io/) にアクセス。
 2. 上記のアドレスを検索し、デプロイTxの確認。
 3. `Contract`タブでソースコードVerifyを実施（後日自動化）。
-> Hardhat Verify を使う場合は [`appendix/verify.md`](../appendix/verify.md) を参照する。
+> Hardhat Verify を使う場合は [`docs/appendix/verify.md`](../appendix/verify.md) を参照する。
 
 ---
 

--- a/docs/curriculum/Day04_Solidity_Basics.md
+++ b/docs/curriculum/Day04_Solidity_Basics.md
@@ -13,7 +13,7 @@
 ## 0. 前提
 - Day3 までの環境構築が完了している（`npm ci` / `.env`）
 - Sepolia にデプロイする場合は、`SEPOLIA_RPC_URL` と `PRIVATE_KEY` を設定し、少額のテストETHを入れておく
-- 先に読む付録：[`appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
+- 先に読む付録：[`docs/appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
 - 触るファイル（主なもの）：`contracts/WalletBox.sol` / `test/walletbox.ts` / `scripts/deploy-walletbox.ts`
 - 今回触らないこと：複雑な権限設計（AccessControl）やアップグレード（Proxy）
 - 最短手順（迷ったらここ）：2.1 の `WalletBox.sol` を追加 → 2.2 のテストを追加 → `npm test` で確認

--- a/docs/curriculum/Day05_ERC_Standards.md
+++ b/docs/curriculum/Day05_ERC_Standards.md
@@ -15,7 +15,7 @@
 - Day3 までの環境構築が完了している（`npm ci` / `.env`）
 - Sepolia にデプロイする場合は、`SEPOLIA_RPC_URL` と `PRIVATE_KEY` を設定し、少額のテストETHを入れておく
 - Verify（任意）をやる場合は `ETHERSCAN_API_KEY` も必要
-- 先に読む付録：[`appendix/glossary.md`](../appendix/glossary.md) / [`appendix/verify.md`](../appendix/verify.md)（任意）
+- 先に読む付録：[`docs/appendix/glossary.md`](../appendix/glossary.md) / [`docs/appendix/verify.md`](../appendix/verify.md)（任意）
 - 触るファイル（主なもの）：
   - ERC‑20：`contracts/MyToken.sol` / `scripts/deploy-token.ts` / `test/erc20.ts`
   - ERC‑721：`contracts/MyNFT.sol` / `scripts/deploy-nft.ts` / `scripts/mint-nft.ts` / `test/mynft.ts`
@@ -180,7 +180,7 @@ npm i -D @nomicfoundation/hardhat-verify
 npx hardhat verify --network sepolia <TOKEN_ADDRESS> 1000000000000000000000000
 npx hardhat verify --network sepolia <NFT_ADDRESS> "ipfs://<CID>/" <ROYALTY_RECEIVER_ADDR> 500
 ```
-> つまずいたら [`appendix/verify.md`](../appendix/verify.md) を参照する（コンストラクタ引数・optimizer設定・APIキーの不足が典型）。
+> つまずいたら [`docs/appendix/verify.md`](../appendix/verify.md) を参照する（コンストラクタ引数・optimizer設定・APIキーの不足が典型）。
 
 ---
 
@@ -196,7 +196,7 @@ npx hardhat verify --network sepolia <NFT_ADDRESS> "ipfs://<CID>/" <ROYALTY_RECE
 |---|---|---|
 | `import \"@openzeppelin/...\"` が解決できない | 依存が入っていない | ルートで `npm ci`（または `npm i @openzeppelin/contracts`）を実行する |
 | スクリプトが落ちる（`TOKEN` など） | 環境変数未設定 / `--network` 不一致 | `TOKEN`/`NFT_ADDRESS` 等の値と、`--network` を見直す |
-| Verifyが失敗する | APIキー/引数/コンパイラ設定不一致 | [`appendix/verify.md`](../appendix/verify.md) を参照し、引数と optimizer 等を合わせる |
+| Verifyが失敗する | APIキー/引数/コンパイラ設定不一致 | [`docs/appendix/verify.md`](../appendix/verify.md) を参照し、引数と optimizer 等を合わせる |
 
 ---
 

--- a/docs/curriculum/Day06_Local_Testing.md
+++ b/docs/curriculum/Day06_Local_Testing.md
@@ -14,7 +14,7 @@
 ## 0. 前提
 - ルートで `npm ci` 済み（依存が入っている）
 - 以降の手順は、このリポジトリ直下で実行する
-- 先に読む付録：[`appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
+- 先に読む付録：[`docs/appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
 - 触るファイル（主なもの）：`hardhat.config.ts` / `contracts/GasBench.sol` / `test/gasbench.ts` / `.github/workflows/test.yml`（任意）
 - 今回触らないこと：テストネット/本番へのデプロイ（Day7以降）
 - 最短手順（迷ったらここ）：4章のコマンドで `npm test` を実行 → gasReporter出力を見て差分を確認（coverageは任意）

--- a/docs/curriculum/Day08_L2_Rollups.md
+++ b/docs/curriculum/Day08_L2_Rollups.md
@@ -14,7 +14,7 @@
 ## 0. 前提
 - Day3 までの環境構築が完了している（`npm ci` / `.env`）
 - L2（例：Optimism）へ送る場合は、対象チェーン側に手数料分のETHが必要だ（ブリッジ等で用意する）
-- 先に読む付録：[`appendix/verify.md`](../appendix/verify.md)（任意：L2でVerifyする場合）
+- 先に読む付録：[`docs/appendix/verify.md`](../appendix/verify.md)（任意：L2でVerifyする場合）
 - 触るファイル（主なもの）：`scripts/deploy-generic.ts` / `scripts/measure-fee.ts` / `scripts/measure-contract.ts` / `metrics/metrics.csv`
 - 今回触らないこと：各L2の運用最適解（まずは「Blob前提のコスト構造」を押さえる）
 - 最短手順（迷ったらここ）：2.2 でL2へ再デプロイ → 3.1 で `measure-fee.ts` を回してL1/L2の差分を記録（Verifyは任意）
@@ -101,7 +101,7 @@ CONTRACT=MyToken ARGS=1000000000000000000000 \
 ```bash
 npx hardhat verify --network optimism <DEPLOYED_ADDR> 1000000000000000000000
 ```
-> Optimism の Verify には `OPTIMISTIC_ETHERSCAN_API_KEY` が必要。つまずいたら [`appendix/verify.md`](../appendix/verify.md) を参照する。
+> Optimism の Verify には `OPTIMISTIC_ETHERSCAN_API_KEY` が必要。つまずいたら [`docs/appendix/verify.md`](../appendix/verify.md) を参照する。
 
 ---
 
@@ -160,7 +160,7 @@ cat /tmp/op.json | tools/to-csv.sh >> metrics.csv
 | 症状 | 原因 | 対策 |
 |---|---|---|
 | `insufficient funds` | L2で手数料不足 | L2のETHをブリッジまたは取引所から供給 |
-| Verify失敗 | コンパイラ設定差分 | `hardhat.config.ts` の設定を一致させる。詰まったら [`appendix/verify.md`](../appendix/verify.md) |
+| Verify失敗 | コンパイラ設定差分 | `hardhat.config.ts` の設定を一致させる。詰まったら [`docs/appendix/verify.md`](../appendix/verify.md) |
 | 異常な`latencyMs` | RPC遅延/混雑 | 別RPCで再測、再試行、バッチ間隔を変える |
 
 ---

--- a/docs/curriculum/Day09_DApp_Frontend.md
+++ b/docs/curriculum/Day09_DApp_Frontend.md
@@ -16,7 +16,7 @@
 - Day5 で `MyToken` をデプロイして、アドレスを控えている。
 - ブラウザにMetaMask等のウォレット拡張が入っている。
 - ミニプロジェクト（通しで作るもの）：Day14 を“完成”としてつなぐ（全体像：[`docs/curriculum/Project.md`](./Project.md)）
-- 先に読む付録：[`appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
+- 先に読む付録：[`docs/appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
 - 触るファイル（主なもの）：`dapp/.env.local` / `dapp/src/App.tsx` / `dapp/src/lib/web3.ts`
 - 今回触らないこと：UI/UXの作り込み（接続と切り分けが主題）
 - 最短手順（迷ったらここ）：1章で `dapp/` を起動 → `.env.local` に chainId/アドレス設定 → 画面で Connect/Switch/Send を確認

--- a/docs/curriculum/Day10_Events_TheGraph.md
+++ b/docs/curriculum/Day10_Events_TheGraph.md
@@ -16,7 +16,7 @@
 - `EventToken` を任意ネットワークへデプロイできる（ローカル/テストネット/L2のどれでもよい）。
 - ミニプロジェクト（通しで作るもの）：`EventToken` は Day14 の統合でも使う（全体像：[`docs/curriculum/Project.md`](./Project.md)）
 - The Graph で詰まりやすい点は [`docs/appendix/the-graph.md`](../appendix/the-graph.md) の「最短成功ルート」→「失敗時の切り分け」→「よくあるエラー表」を参照する。
-- 先に読む付録：[`docs/appendix/the-graph.md`](../appendix/the-graph.md) / [`appendix/glossary.md`](../appendix/glossary.md)
+- 先に読む付録：[`docs/appendix/the-graph.md`](../appendix/the-graph.md) / [`docs/appendix/glossary.md`](../appendix/glossary.md)
 - 触るファイル（主なもの）：`contracts/EventToken.sol` / `scripts/deploy-event-token.ts` / `scripts/use-event-token.ts` / `dapp/src/hooks/useEvents.ts`
 - 今回触らないこと：本番運用のインデックス設計（まずは“作って動かす”）
 - 最短手順（迷ったらここ）：2章でイベント発火 → 3章でdapp購読表示 →（任意）4章でThe Graphのひな形生成

--- a/docs/curriculum/Day11_NFT_Metadata.md
+++ b/docs/curriculum/Day11_NFT_Metadata.md
@@ -14,7 +14,7 @@
 ## 0. 前提
 - PinataまたはInfura IPFS（Project ID/Secret）を用意。
 - 画像ファイル（例：`assets/1.png`）。
-- 先に読む付録：[`appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
+- 先に読む付録：[`docs/appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
 - 触るファイル（主なもの）：`contracts/MyNFT.sol` / `scripts/deploy-nft.ts` / `scripts/mint-nft.ts` / `contracts/FixedPriceMarket.sol` / `test/mynft.ts`
 - 今回触らないこと：NFTマーケットの本格実装（まずはtokenURI/IPFSの流れを固める）
 - 最短手順（迷ったらここ）：2章でIPFSに配置 → 3章の `MyNFT` をデプロイ → 4章でミント → `tokenURI`/Gatewayで表示確認

--- a/docs/curriculum/Day12_Security.md
+++ b/docs/curriculum/Day12_Security.md
@@ -14,7 +14,7 @@
 ## 0. 前提
 - Hardhat環境（Day3）。
 - 任意でFoundry（`foundryup` 済）。
-- 先に読む付録：[`appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
+- 先に読む付録：[`docs/appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
 - 触るファイル（主なもの）：`contracts/VulnBank.sol` / `contracts/SafeBank.sol` / `contracts/Attacker.sol` / `test/reentrancy.ts` / `contracts/AdminBox.sol`
 - 今回触らないこと：すべての脆弱性の網羅（まずは頻出の再入と権限の基本から）
 - 最短手順（迷ったらここ）：1章のコントラクト/テストを動かして“攻撃できる/防げる”を体験 → `npx hardhat test test/reentrancy.ts` で確認

--- a/docs/curriculum/Day13_Gas_Optimization.md
+++ b/docs/curriculum/Day13_Gas_Optimization.md
@@ -14,7 +14,7 @@
 ## 0. 前提
 - Day6で `hardhat-gas-reporter` を導入済み。
 - 任意でFoundryの `gas-snapshot` を併用可。
-- 先に読む付録：[`appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
+- 先に読む付録：[`docs/appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
 - 触るファイル（主なもの）：`contracts/GasPack.sol` / `test/gas-pack.ts` / `contracts/GasArgs.sol` / `test/gas-args.ts` / `metrics/gas_day13.md`
 - 今回触らないこと：最小可読性を捨てる極限最適化（まずは“効くポイント”を実測で掴む）
 - 最短手順（迷ったらここ）：2章/3章のテストを個別に実行してガス差を確認 → 表にまとめる（例：`npx hardhat test test/gas-pack.ts`）

--- a/docs/curriculum/Part2.md
+++ b/docs/curriculum/Part2.md
@@ -18,8 +18,8 @@
 2) Day7：デプロイ/Verify/CI：[`Day07_Deploy_CI.md`](./Day07_Deploy_CI.md)
 
 ## 先に読む付録（詰まったらここ）
-- Verify：[`appendix/verify.md`](../appendix/verify.md)
-- GitHub Actions / CI：[`appendix/ci-github-actions.md`](../appendix/ci-github-actions.md)
+- Verify：[`docs/appendix/verify.md`](../appendix/verify.md)
+- GitHub Actions / CI：[`docs/appendix/ci-github-actions.md`](../appendix/ci-github-actions.md)
 
 ## チェックリスト（ここまでできれば次へ進める）
 - [ ] `npm test` が通る（ローカル）
@@ -29,4 +29,3 @@
 ---
 
 [← 目次](./TOC.md)
-

--- a/docs/curriculum/Part3.md
+++ b/docs/curriculum/Part3.md
@@ -19,7 +19,7 @@
 3) Day10：イベント/The Graph：[`Day10_Events_TheGraph.md`](./Day10_Events_TheGraph.md)
 
 ## 先に読む付録（詰まったらここ）
-- The Graph：[`appendix/the-graph.md`](../appendix/the-graph.md)
+- The Graph：[`docs/appendix/the-graph.md`](../appendix/the-graph.md)
 
 ## チェックリスト（ここまでできれば次へ進める）
 - [ ] Day9の `dapp/` をビルドできる（`npm --prefix dapp ci` → `npm --prefix dapp run build`）
@@ -28,4 +28,3 @@
 ---
 
 [← 目次](./TOC.md)
-

--- a/docs/curriculum/Part5.md
+++ b/docs/curriculum/Part5.md
@@ -13,9 +13,9 @@
 1) Day14：統合：[`Day14_Integration.md`](./Day14_Integration.md)
 
 ## 先に読む付録（任意だが詰まりやすい）
-- Verify：[`appendix/verify.md`](../appendix/verify.md)
-- GitHub Actions / CI：[`appendix/ci-github-actions.md`](../appendix/ci-github-actions.md)
-- The Graph：[`appendix/the-graph.md`](../appendix/the-graph.md)
+- Verify：[`docs/appendix/verify.md`](../appendix/verify.md)
+- GitHub Actions / CI：[`docs/appendix/ci-github-actions.md`](../appendix/ci-github-actions.md)
+- The Graph：[`docs/appendix/the-graph.md`](../appendix/the-graph.md)
 
 ## チェックリスト（ここまでできれば完走）
 - [ ] Day14のチェックリストを “Done” にできる（全部でなくてもよい）
@@ -24,4 +24,3 @@
 ---
 
 [← 目次](./TOC.md)
-

--- a/docs/curriculum/TOC.md
+++ b/docs/curriculum/TOC.md
@@ -47,12 +47,12 @@
 ---
 
 ## 付録（つまずきやすい所）
-- 用語集：[`../appendix/glossary.md`](../appendix/glossary.md)
-- Verify：[`../appendix/verify.md`](../appendix/verify.md)
-- GitHub Actions / CI：[`../appendix/ci-github-actions.md`](../appendix/ci-github-actions.md)
-- The Graph：[`../appendix/the-graph.md`](../appendix/the-graph.md)
-- Account Abstraction（ERC‑4337 / EIP‑7702）：[`../appendix/account-abstraction.md`](../appendix/account-abstraction.md)
-- リソース集：[`../appendix/Appendix_Resources.md`](../appendix/Appendix_Resources.md)
+- 用語集：[`docs/appendix/glossary.md`](../appendix/glossary.md)
+- Verify：[`docs/appendix/verify.md`](../appendix/verify.md)
+- GitHub Actions / CI：[`docs/appendix/ci-github-actions.md`](../appendix/ci-github-actions.md)
+- The Graph：[`docs/appendix/the-graph.md`](../appendix/the-graph.md)
+- Account Abstraction（ERC‑4337 / EIP‑7702）：[`docs/appendix/account-abstraction.md`](../appendix/account-abstraction.md)
+- リソース集：[`docs/appendix/Appendix_Resources.md`](../appendix/Appendix_Resources.md)
 
 ## 実行ログ（再現用）
 各Dayの「期待される出力例」として、`reports/` に実行ログを置いている。

--- a/docs/curriculum/_Chapter_Template.md
+++ b/docs/curriculum/_Chapter_Template.md
@@ -19,7 +19,7 @@
 ## 0. 前提
 - OS：Linux/macOS/WSL2（例）
 - 必要コマンド：`node` / `npm` / `git`（例）
-- 先に読む付録：`appendix/glossary.md` / `appendix/verify.md`（例）
+- 先に読む付録：`docs/appendix/glossary.md` / `docs/appendix/verify.md`（例）
 - 触るファイル（主なもの）：`contracts/...` / `scripts/...` / `test/...`（例）
 - 今回触らないこと：例）本番運用の最適解、巨大な設計論（まずは最小を動かす）
 - 最短手順（迷ったらここ）：例）2章を順に実行 → `npm test` で確認 → 章末の提出物を埋める

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ permalink: /
 1. 共通の前提を読む：[`curriculum/README.md`]({{ '/curriculum/README/' | relative_url }})
 2. 通しで作るもの（ミニプロジェクト）：[`curriculum/Project.md`]({{ '/curriculum/Project/' | relative_url }})
 3. 読み方ガイド：[`curriculum/Guide.md`]({{ '/curriculum/Guide/' | relative_url }})
-4. 用語に迷ったら：[`appendix/glossary.md`]({{ '/appendix/glossary/' | relative_url }})
+4. 用語に迷ったら：[`docs/appendix/glossary.md`]({{ '/appendix/glossary/' | relative_url }})
 5. 目次どおりに進める：[`curriculum/TOC.md`]({{ '/curriculum/TOC/' | relative_url }})
 
 ## Quick Start（ローカル検証）
@@ -42,9 +42,9 @@ npm test
 - 全体の目次：[`curriculum/TOC.md`]({{ '/curriculum/TOC/' | relative_url }})
 
 ## つまずきポイント（先に読む）
-- Verify：[`appendix/verify.md`]({{ '/appendix/verify/' | relative_url }})
-- GitHub Actions / CI：[`appendix/ci-github-actions.md`]({{ '/appendix/ci-github-actions/' | relative_url }})
-- The Graph：[`appendix/the-graph.md`]({{ '/appendix/the-graph/' | relative_url }})
+- Verify：[`docs/appendix/verify.md`]({{ '/appendix/verify/' | relative_url }})
+- GitHub Actions / CI：[`docs/appendix/ci-github-actions.md`]({{ '/appendix/ci-github-actions/' | relative_url }})
+- The Graph：[`docs/appendix/the-graph.md`]({{ '/appendix/the-graph/' | relative_url }})
 
 ## 更新履歴
 - 現行バージョン：v{{ site.version }}

--- a/docs/reports/Day10.md
+++ b/docs/reports/Day10.md
@@ -26,4 +26,4 @@ EVT=<EVT> npx hardhat run scripts/use-event-token.ts --network localhost
 - ただし `dapp/` は injected provider（MetaMask等）前提のため、この環境ではUI表示まで未確認。
 
 ## The Graph（未実施）
-- 生成物は同梱しない運用。`subgraph/README.md` と `appendix/the-graph.md` を参照。
+- 生成物は同梱しない運用。`docs/subgraph/README.md` と `docs/appendix/the-graph.md` を参照。

--- a/docs/reports/Day14.md
+++ b/docs/reports/Day14.md
@@ -60,6 +60,6 @@ TOKEN=<TOKEN> npx hardhat run scripts/measure-contract.ts --network localhost
 
 ## DApp / Verify / CI / The Graph（入口）
 - DApp：`cd dapp && npm ci && npm run build` が成功（UI動作はMetaMask等が必要）。
-- Verify：`appendix/verify.md`
+- Verify：`docs/appendix/verify.md`
 - CI：`.github/workflows/test.yml`（PR/Pushで `npm test`）
-- The Graph：`appendix/the-graph.md` / `subgraph/README.md`
+- The Graph：`docs/appendix/the-graph.md` / `docs/subgraph/README.md`


### PR DESCRIPTION
## 概要
教材内で付録への参照が `appendix/...` と表示されている箇所を、本文の位置づけ（`docs/` 配下）に合わせて **表示ラベルを `docs/appendix/...` に統一**しました。

- リンクURL（`../appendix/...` や `relative_url`）は原則変更していません
- 初学者が「このリポジトリのどこを見ればいいか」を迷いにくくするための表記揃えです

## 影響範囲
- `docs/index.md` / `docs/appendix/index.md` / `docs/curriculum/*` / `docs/reports/*`

## 確認
- `npm run check:all`
