### PR TITLE
docs(curriculum): link progress checklist

### DIFF
--- a/docs/curriculum/Project.md
+++ b/docs/curriculum/Project.md
@@ -11,6 +11,8 @@ description: "Day01〜Day14 を通して、MyToken / EventToken / DApp を“1�
 
 > まず [`docs/curriculum/README.md`](./README.md) の「共通の前提」を確認してから進める。
 
+> 進捗チェック（完走チェックリスト）：[`docs/curriculum/Progress.md`](./Progress.md)
+
 ---
 
 ## 1. 何を作るか（完成イメージ）

--- a/docs/curriculum/README.md
+++ b/docs/curriculum/README.md
@@ -6,6 +6,7 @@
 読む順序は [`docs/curriculum/TOC.md`](./TOC.md) を参照する。
 目的別の進め方（学習ルート）は [`docs/curriculum/Guide.md`](./Guide.md) を参照する。
 通しで作るもの（ミニプロジェクト）は [`docs/curriculum/Project.md`](./Project.md) を参照する。
+進捗チェック（完走チェックリスト）は [`docs/curriculum/Progress.md`](./Progress.md) を参照する。
 
 ## 0. 表記ルール（この本の読み方）
 - `<...>` は **自分の値に置き換える**（例：`<YOUR_API_KEY>`, `<PRIVATE_KEY>`, `<CONTRACT_ADDRESS>`）。


### PR DESCRIPTION
## 概要
`docs/curriculum/Progress.md`（進捗チェック）への導線を、入口になりやすいページからも追加しました。

- `docs/curriculum/README.md`
- `docs/curriculum/Project.md`

## 確認
- `npm run check:all`
