### PR TITLE
CI: docs禁止物チェックを追加

### DIFF
--- a/.github/workflows/docs-forbidden-check.yml
+++ b/.github/workflows/docs-forbidden-check.yml
@@ -1,13 +1,20 @@
 name: Docs Forbidden Check
 
 on:
-  pull_request:
   push:
-    branches: [ main ]
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
 
 jobs:
   docs-forbidden:
+    name: Docs forbidden check
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,11 +27,16 @@ jobs:
             "docs/src"
             "docs/package.json"
             "docs/node_modules"
+            "docs/_site"
           )
+          found=0
           for path in "${forbidden[@]}"; do
-            if [ -e "$path" ]; then
-              echo "Forbidden path exists: $path"
-              exit 1
+            if [ -e "$path" ] || [ -L "$path" ]; then
+              echo "Forbidden path exists: $path" >&2
+              found=1
             fi
           done
-          echo "docs forbidden items: OK"
+          if [ "$found" -ne 0 ]; then
+            exit 1
+          fi
+          echo "docs 禁止物チェック: OK"


### PR DESCRIPTION
docs/ に生成物や管理用フォルダが混入しないよう、禁止物チェックをCIに追加します。