### PR TITLE
fix(docs): remove nonexistent links from chapter template

### DIFF
--- a/docs/curriculum/_Chapter_Template.md
+++ b/docs/curriculum/_Chapter_Template.md
@@ -6,7 +6,7 @@
 
 # DayXX：タイトルを書く
 
-[← 目次](./TOC.md) | [前: DayYY](./DayYY_Example.md) | [次: DayZZ](./DayZZ_Example.md)
+[← 目次](./TOC.md) | 前: DayYY | 次: DayZZ
 
 ## 学習目的
 - 例：〜を説明できるようになる。
@@ -69,7 +69,7 @@ npm test
 - [ ] 例：デプロイアドレス（秘密情報は載せない）
 
 ## 6. 実行例
-- 実行ログ例：[`docs/reports/DayXX.md`](../reports/DayXX.md)
+- 実行ログ例：`docs/reports/DayXX.md`（存在する場合はリンク化する）
 
 ---
 


### PR DESCRIPTION
目的: 執筆用テンプレート（docs/curriculum/_Chapter_Template.md）に存在しないファイルへのMarkdownリンクがあり、内部リンクチェックでbrokenになるため修正。

対応内容:
- DayYY/DayZZ の例示リンクをプレーンテキストに変更（テンプレ利用時に実ファイルへ置換する前提）
- DayXX レポートの例示リンクをプレーンテキストに変更（存在する場合のみリンク化する運用に）

確認:
- check-links: brokenLinks=0（ローカル: book-formatter/scripts/check-links.js）

関連:
- https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102
