### PR TITLE
docs: fix Issue #93 curriculum inconsistencies

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,3 +12,6 @@
 - 付録を強化（Verify / CI / The Graph / Account Abstraction など）
 - CI に Markdown 相対リンクチェックと DApp build を追加
 - 実行ログ（`docs/reports/`）を整備し、再現手順の確認に使えるようにした
+
+## 2026.02
+- Issue #93 対応：教材の正誤・不整合を修正（Day1/2 の記録先統一、Day1 のコマンドと出力例の整合、Day3 の導線整理、Day12 のツール説明の誤解低減 など）

--- a/docs/curriculum/Day01_Ethereum_Intro.md
+++ b/docs/curriculum/Day01_Ethereum_Intro.md
@@ -16,7 +16,7 @@
 - 必要なもの：Sepolia などの RPC エンドポイント（Alchemy/Infura 等）
 - この章は **Tx を送らない**。テストETHは不要だ。
 - 先に読む付録：[`docs/appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
-- 触るファイル（主なもの）：（任意）`REPORT.md`
+- 触るファイル（主なもの）：（任意）`docs/reports/Day01.md`（実行ログ）
 - 今回触らないこと：秘密鍵で署名してTxを送る／コントラクトのデプロイ（Day3以降で扱う）
 - 最短手順（迷ったらここ）：RPCを `RPC` に設定 → 2.3 でブロック番号 → 2.4 でブロック詳細 → 2.5 で3ブロック比較
 
@@ -51,7 +51,7 @@
   - トランザクション実行をL2で行い、結果をL1に保存。
   - 近年は **rollup-centric（L2中心）** のスケーリングが前提で、L2手数料は「L1へ投稿するデータ可用性（[DA](../appendix/glossary.md)）コスト」の影響が大きくなりやすい（詳細はDay8）。
     - **Dencun（EIP‑4844）** で blob-carrying transactions（[Blob](../appendix/glossary.md)）が導入され、L2のDAコストが下がりやすくなった。
-    - **Pectra（EIP‑7691）** では blob の throughput が増え、blob の target/max が **3/6 → 6/9** に引き上げられている。
+    - **Pectra（EIP‑7691）** では blob の throughput が増え、blob の target/max が **3/6 → 6/9** に引き上げられる（注：有効化タイミングはネットワークや時期で異なる。実測と公式情報を優先する）。
 
 ---
 
@@ -115,9 +115,12 @@ curl -s -X POST "$RPC" -H 'Content-Type: application/json' \
 ```json
 {
   "number": "0x158b4c9",
+  "hash": "0x...",
   "baseFeePerGas": "0x19a3af8b6",
   "gasUsed": "0x5f9d03",
   "gasLimit": "0x1c9c380",
+  "miner": "0x...",
+  "timestamp": "0x...",
   "transactions": 143
 }
 ```
@@ -181,10 +184,9 @@ curl -s -X POST "$RPC" \
 ```
 
 ## 5. 提出物
-- [ ] `REPORT.md` を作成し、次を記載する：
-  - [ ] 実行したコマンドと出力例
-  - [ ] 3ブロック分の混雑度分析
-  - [ ] 学んだ内容を3行で要約
+- [ ] `docs/reports/Day01.md` に、実行したコマンドと出力例を記録する
+- [ ] `docs/reports/Day01.md` に、3ブロック分の混雑度分析を記録する
+- [ ] `docs/reports/Day01.md` に、学んだ内容を3行で要約する
 
 ## 6. 実行例
 - 実行ログ例：[`docs/reports/Day01.md`](../reports/Day01.md)

--- a/docs/curriculum/Day02_Transaction_Gas.md
+++ b/docs/curriculum/Day02_Transaction_Gas.md
@@ -14,7 +14,7 @@
 - Day1 で `RPC` を設定済み（2.5 の CLI パートで使う）
 - Remix IDE を使う場合はブラウザで操作する（ウォレット連携は環境により異なる）
 - 先に読む付録：[`docs/appendix/glossary.md`](../appendix/glossary.md)（用語に迷ったとき）
-- 触るファイル（主なもの）：（任意）`REPORT.md`
+- 触るファイル（主なもの）：（任意）`docs/reports/Day02.md`（実行ログ）
 - 今回触らないこと：ガス最適化の細部（Day13）／ガス計測の実装（Day6）
 - 最短手順（迷ったらここ）：2.2 でコントラクト作成 → 2.3 で `store/add` の違い確認 → 2.4 でEtherscan解析（2.5は任意）
 
@@ -193,10 +193,9 @@ curl -s -X POST "$RPC" -H 'Content-Type: application/json' \
 ```
 
 ## 5. 提出物
-- [ ] `REPORT.md` を作成し、次を記載する：
-  - [ ] `store()`（Tx）のGas Used と、2.6 の3パターンのGas差（表形式）
-  - [ ] Etherscanで確認したTx詳細（スクリーンショットまたは値）
-  - [ ] 2.6の追加実験の結果（3パターンの比較）
+- [ ] `docs/reports/Day02.md` に、`store()`（Tx）のGas Used と 2.6 の3パターンのGas差を表形式で記録する
+- [ ] `docs/reports/Day02.md` に、Etherscanで確認したTx詳細（スクリーンショットまたは値）を記録する
+- [ ] `docs/reports/Day02.md` に、2.6 の追加実験の結果（3パターンの比較）を記録する
 
 ## 6. 実行例
 - 実行ログ例：[`docs/reports/Day02.md`](../reports/Day02.md)

--- a/docs/curriculum/Day03_Env_Setup.md
+++ b/docs/curriculum/Day03_Env_Setup.md
@@ -90,6 +90,8 @@ MTK: 0x...
 ### 2.1 環境構築（参考：ゼロから作る場合）
 この節は「本リポジトリを使わず、ゼロから Hardhat プロジェクトを作る」場合の参考だ。迷ったら 2.0 を優先する。
 
+> 注意：以降の章は **本リポジトリの構成（`package.json` / lockfile で依存固定）** を前提にしている。2.1 の手順で作った別プロジェクトに、教材のコードをそのまま混ぜないこと（依存差分で再現性が落ちやすい）。教材を進める場合は、本リポジトリに戻って 2.0 の `npm ci` を実行する。
+
 #### 2.1.0 この節のゴール（成功判定）
 - `node -v` が v20 系になっている
 - `npx hardhat` で TypeScript プロジェクトを作成できる
@@ -129,14 +131,14 @@ npm -v
 ```bash
 mkdir eth-bootcamp && cd eth-bootcamp
 npm init -y
-npm install --save-dev hardhat
+npm install --save-dev hardhat@^2.22.1
 npx hardhat
 ```
 プロンプトで「Create a TypeScript project」を選択。
 
 #### (3) 推奨プラグインの追加
 ```bash
-npm install --save-dev @nomicfoundation/hardhat-toolbox dotenv
+npm install --save-dev @nomicfoundation/hardhat-toolbox@^6.1.0 dotenv@^16.4.5
 ```
 
 #### (4) .envファイルを準備

--- a/docs/curriculum/Day12_Security.md
+++ b/docs/curriculum/Day12_Security.md
@@ -5,7 +5,7 @@
 ## 学習目的
 - 代表的脆弱性（Reentrancy, tx.origin誤用, delegatecall乱用, Proxyのストレージ衝突）を理解し、簡単に説明できるようになる。
 - 対策（CEI, ReentrancyGuard, AccessControl/Ownable, Pull-Payment, Pausable）を実装し、テストで検証できるようになる。
-- Slither（静的解析）とFoundry/Echidna（プロパティテスト）を実行し、自動検出を体験できるようになる。
+- Slither（静的解析）、Foundry（テスト + fuzz / invariant）、Echidna（任意：別系統のプロパティベーステスト/ファジング）を実行し、自動検出を体験できるようになる。
 
 > まず [`docs/curriculum/README.md`](./README.md) の「共通の前提」を確認してから進める。
 
@@ -192,7 +192,10 @@ slither . --filter-paths "node_modules"
 
 ---
 
-## 6. ツール：Foundry/Echidna（プロパティテスト）
+## 6. ツール：Foundry（テスト + fuzz / invariant）とEchidna（任意）
+
+Foundry はテストフレームワークで、fuzz（ランダム入力探索）や invariant（永続条件）を内蔵する。  
+Echidna は Foundry の一部ではなく、別系統のツールとしてプロパティベーステスト/ファジングに使われる。
 
 ### 6.1 Invariant（永続条件）例（Foundry）
 `test/Invariant.t.sol`


### PR DESCRIPTION
## 概要
Issue #93 の指摘に沿って、教材 `docs/` の不整合を修正しました。

## 変更点
- Day1: `jq` の抽出フィールドと出力例を一致（`hash` / `miner` / `timestamp` を例に追加）
- Day1/Day2: 提出物の記録先を `docs/reports/DayXX.md` に統一（`REPORT.md` 参照を削除）
- Day3: 「ゼロからHardhat」を教材本体と混同しない注意書きを追加し、参考手順の Hardhat/toolbox/dotenv を教材の依存に合わせてバージョン指定
- Day12: Foundry と Echidna の位置付けを整理（Foundry=テスト+fuzz/invariant、Echidna=別系統ツール）

## Done（Issue #93）
- [x] Day3 の手順が `npm ci` 前提と矛盾しない
- [x] Day1 のコマンドと出力例が一致
- [x] Day12 のツール分類が誤解を招かない表現
- [x] 「提出物/記録先」の方針が一貫（Day1/Day2 の `REPORT.md` を撤去して `docs/reports/` に統一）

注：Issue 本文の「表崩れ（`|—|—|—|`）」と「Day6 timeout 表記」は、`main` 時点で横断検索・確認した限り再現しませんでした（本PRでは追加変更なし）。

## テスト
- `npm run check:all`

Closes #93
