### PR TITLE
docs: Pectra/EIP-7691 status + RPC placeholders (Issue #98)

### DIFF
--- a/docs/curriculum/Day01_Ethereum_Intro.md
+++ b/docs/curriculum/Day01_Ethereum_Intro.md
@@ -51,7 +51,10 @@
   - トランザクション実行をL2で行い、結果をL1に保存。
   - 近年は **rollup-centric（L2中心）** のスケーリングが前提で、L2手数料は「L1へ投稿するデータ可用性（[DA](../appendix/glossary.md)）コスト」の影響が大きくなりやすい（詳細はDay8）。
     - **Dencun（EIP‑4844）** で blob-carrying transactions（[Blob](../appendix/glossary.md)）が導入され、L2のDAコストが下がりやすくなった。
-    - **Pectra（EIP‑7691）** では blob の throughput が増え、blob の target/max が **3/6 → 6/9** に引き上げられる（注：有効化タイミングはネットワークや時期で異なる。実測と公式情報を優先する）。
+    - **Pectra（EIP‑7691）** では blob の throughput が増え、blob の target/max が **3/6 → 6/9** に引き上げられた。
+      - mainnet: 2025-05-07（epoch 364032）で有効化済み
+      - 注：テストネット/L2 の有効化タイミングはチェーンや時期で異なるため、実測と公式情報を優先する
+      - 参考： https://ethereum.org/roadmap/pectra/
 
 ---
 
@@ -72,7 +75,11 @@ sudo apt update && sudo apt install -y curl jq
 AlchemyまたはInfuraで取得したRPCを設定。
 
 ```bash
-export RPC="https://sepolia.infura.io/v3/<YOUR_API_KEY>"
+# YOUR_API_KEY を自分の値に置換する（APIキーはコミットしない）
+export RPC="https://sepolia.infura.io/v3/YOUR_API_KEY"
+
+# 例（Alchemy）
+# export RPC="https://eth-sepolia.g.alchemy.com/v2/YOUR_API_KEY"
 ```
 
 確認：

--- a/docs/curriculum/Day03_Env_Setup.md
+++ b/docs/curriculum/Day03_Env_Setup.md
@@ -145,15 +145,16 @@ npm install --save-dev @nomicfoundation/hardhat-toolbox@6.1.0 dotenv@16.4.5
 #### (4) .envファイルを準備
 ```bash
 cat > .env.example <<'ENV'
-SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/<YOUR_KEY>
-PRIVATE_KEY=0x<YOUR_PRIVATE_KEY>
-ETHERSCAN_API_KEY=<YOUR_KEY>
+SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_API_KEY
+PRIVATE_KEY=0xYOUR_PRIVATE_KEY
+ETHERSCAN_API_KEY=YOUR_ETHERSCAN_API_KEY
 ENV
 ```
 コピーして設定：
 ```bash
 cp .env.example .env && nano .env
 ```
+> `YOUR_...` は自分の値に置換する。APIキーや秘密鍵はコミットしない。
 
 ---
 

--- a/docs/curriculum/Day08_L2_Rollups.md
+++ b/docs/curriculum/Day08_L2_Rollups.md
@@ -47,7 +47,7 @@ L2手数料 ≒ L2実行コスト + L1データ可用性（Blob）コスト
 このため、L2上で同じ操作をしても **Blobの混雑**（base fee）次第で費用が変動する。
 
 ### 1.5 Pectra（EIP‑7691）：Blob throughput increase
-**EIP‑7691（提案）** では、Blob の供給枠が増える。
+**EIP‑7691** は Pectra で **有効化済み** で、Blob の供給枠が増える。
 
 | パラメータ（1ブロックあたり） | EIP‑4844 初期値 | EIP‑7691（Pectra） |
 |---|---:|---:|
@@ -57,7 +57,11 @@ L2手数料 ≒ L2実行コスト + L1データ可用性（Blob）コスト
 - **target**：この値を基準に blob の base fee が上下しやすい（混雑の“中心”）。
 - **max**：1ブロックで許容される上限。
 
-> 注：アップグレードの有効化タイミングはチェーンや時期で異なる。実際のネットワーク状況は各チェーンの公式アナウンスやEIPを確認すること。
+> 注：mainnet では 2025-05-07（epoch 364032）に有効化済み。テストネット/L2 の有効化タイミングはチェーンや時期で異なるため、実測と公式情報を優先する。  
+> 参考：  
+> - https://ethereum.org/roadmap/pectra/  
+> - https://blog.ethereum.org/2025/04/23/pectra-mainnet  
+> - https://eips.ethereum.org/EIPS/eip-7691
 
 ### 1.6 比較観点
 


### PR DESCRIPTION
Closes #98

## 変更内容
- Day8: EIP-7691 を「提案」ではなく Pectra で有効化済みの説明に統一し、mainnet 有効化（2025-05-07 / epoch 364032）の注記と参考リンクを追記
- Day1: EIP-7691（target/max 3/6→6/9）を「引き上げられた」に統一し、mainnet 有効化の注記と参考リンクを追記
- Day1/Day3: RPCエンドポイント例を `YOUR_API_KEY` 等のプレースホルダで明確化（コピペで置換箇所が分かる形）

## 確認
- `npm run check:all`
- Book QA 相当（pinned book-formatter）: unicode / textlint / links / layout-risk / markdown-structure
}