### PR TITLE
docs: Day03 nvm init fix + nvm version check (Issue #100)

### DIFF
--- a/docs/curriculum/Day03_Env_Setup.md
+++ b/docs/curriculum/Day03_Env_Setup.md
@@ -109,11 +109,13 @@ MTK: 0x...
 **A. nvm（推奨）**
 ```bash
 sudo apt update && sudo apt install -y git curl ca-certificates
+# 注意：curl | bash の実行前に、公式スクリプト（install.sh）の内容を確認する
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash
 
 # 以降はシェルを再起動するか、次を実行
 export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \\. "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+command -v nvm && nvm --version
 
 nvm install 20
 nvm use 20


### PR DESCRIPTION
Closes #100

## 変更内容
- Day03 の nvm 初期化コマンドを `\.` → `\.`（コピペで `\.: command not found` が出ない形）に修正
- 読み込み成功の確認として `command -v nvm && nvm --version` を追記
- `curl | bash` 実行前に、公式スクリプト確認の注意書きを1行追記

## 確認
- `npm run check:all`
- Book QA 相当（pinned book-formatter）: unicode / textlint / links / layout-risk / markdown-structure
}