### PR TITLE
docs: fix copy/paste traps and align deploy examples with repo code

### DIFF
--- a/docs/curriculum/Day07_Deploy_CI.md
+++ b/docs/curriculum/Day07_Deploy_CI.md
@@ -24,9 +24,9 @@
 SEPOLIA_RPC_URL=
 MAINNET_RPC_URL=
 OPTIMISM_RPC_URL=
-PRIVATE_KEY=0x...
-ETHERSCAN_API_KEY=
-OPTIMISTIC_ETHERSCAN_API_KEY=
+PRIVATE_KEY=0xYOUR_PRIVATE_KEY
+ETHERSCAN_API_KEY=YOUR_ETHERSCAN_API_KEY
+OPTIMISTIC_ETHERSCAN_API_KEY=YOUR_OPTIMISTIC_ETHERSCAN_API_KEY
 ```
 
 ---
@@ -34,41 +34,45 @@ OPTIMISTIC_ETHERSCAN_API_KEY=
 ## 1. デプロイスクリプトの汎用化
 `scripts/deploy-generic.ts`
 ```ts
-import { ethers, network } from "hardhat";
+import { ethers, network } from 'hardhat';
 
 // デプロイ対象とコンストラクタ引数は環境変数で指定可能
-// 例: CONTRACT=MyToken ARGS="100000000000000000000" npx hardhat run ...
-async function main(){
-  const name = process.env.CONTRACT || "Lock";
-  const args = (process.env.ARGS||"").split(" ").filter(Boolean);
-  console.log("network:", network.name, "contract:", name, "args:", args);
+// 例: CONTRACT=MyToken ARGS=100000000000000000000 npx hardhat run ...
+async function main() {
+  const name = process.env.CONTRACT || 'Hello';
+  const args = (process.env.ARGS || '').split(' ').filter(Boolean);
+  console.log('network:', network.name, 'contract:', name, 'args:', args);
   const F = await ethers.getContractFactory(name);
   const c = await F.deploy(...(args as any));
   await c.waitForDeployment();
-  console.log("deployed:", await c.getAddress());
+  console.log('deployed:', await c.getAddress());
 }
 
-main().catch((e)=>{console.error(e);process.exit(1)});
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
 ```
 
-**実行例**（MainnetにLockを小額で）
+**実行例**（Sepolia に `Hello` をデプロイ：引数なし）
 ```bash
-npx hardhat run scripts/deploy-generic.ts --network mainnet
+npx hardhat run scripts/deploy-generic.ts --network sepolia
 ```
 **実行例**（OptimismにERC20を供給量指定で）
 ```bash
 CONTRACT=MyToken ARGS=1000000000000000000000000 \
   npx hardhat run scripts/deploy-generic.ts --network optimism
 ```
+> Mainnet に出す場合もコマンドは同じ形で `--network mainnet` を指定するが、実費になるため少額・鍵管理・承認フローを必ず確認する。
 
 ---
 
 ## 2. Verify（ソース検証）
 Hardhat Verifyプラグインを導入（Day5参照）。
 
-**コマンド例（Mainnet：Lock）**
+**コマンド例（Sepolia：Hello）**
 ```bash
-npx hardhat verify --network mainnet <DEPLOYED_ADDR> 3600
+npx hardhat verify --network sepolia <DEPLOYED_ADDR>
 ```
 **コマンド例（Optimism：MyToken）**
 ```bash
@@ -166,11 +170,11 @@ GitHub > Settings > Environments > `production` を作成し、**Required review
 
 ### 確認コマンド（最小）
 ```bash
-# 要 .env（RPC/PRIVATE_KEY）。少額で。
-CONTRACT=Lock ARGS=3600 npx hardhat run scripts/deploy-generic.ts --network sepolia
+# 要 .env（SEPOLIA_RPC_URL / PRIVATE_KEY）。少額で。
+npx hardhat run scripts/deploy-generic.ts --network sepolia
 
-# 任意（Verify：要 ETHERSCAN_API_KEY とデプロイ済みアドレス）
-npx hardhat verify --network sepolia <DEPLOYED_ADDR> 3600
+# 任意（Verify：要 ETHERSCAN_API_KEY とデプロイ済みアドレス。Hello はコンストラクタ引数なし）
+npx hardhat verify --network sepolia <DEPLOYED_ADDR>
 ```
 
 ## 9. 提出物

--- a/docs/curriculum/Day08_L2_Rollups.md
+++ b/docs/curriculum/Day08_L2_Rollups.md
@@ -189,7 +189,7 @@ cat /tmp/op.json | tools/to-csv.sh >> metrics.csv
 ### 確認コマンド（最小）
 ```bash
 # 要 .env（OPTIMISM_RPC_URL / PRIVATE_KEY）と、Optimism 側の手数料分ETH
-CONTRACT=Lock ARGS=3600 npx hardhat run scripts/deploy-generic.ts --network optimism
+npx hardhat run scripts/deploy-generic.ts --network optimism
 
 # ETH転送の手数料を実測（feeEth / latencyMs が出る）
 npx hardhat run scripts/measure-fee.ts --network optimism

--- a/docs/curriculum/index.md
+++ b/docs/curriculum/index.md
@@ -9,7 +9,7 @@
 進捗チェック（完走チェックリスト）は [`docs/curriculum/Progress.md`](./Progress.md) を参照する。
 
 ## 0. 表記ルール（この本の読み方）
-- `<...>` は **自分の値に置き換える**（例：`<YOUR_API_KEY>`, `<PRIVATE_KEY>`, `<CONTRACT_ADDRESS>`）。
+- `<...>` や `YOUR_...` / `0xYOUR_...` は **自分の値に置き換える**（例：`YOUR_API_KEY`, `0xYOUR_PRIVATE_KEY`, `<CONTRACT_ADDRESS>`, `<CID>`）。
 - [Tx](../appendix/glossary.md) はトランザクション（transaction）の略として使う。
 - [RPC](../appendix/glossary.md) はノードと通信するエンドポイント（JSON-RPC）として使う。
 - `0x...` は16進数表記だ。必要に応じて10進数へ変換して読む（Day1参照）。

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,8 @@ permalink: /
 ## Quick Start（ローカル検証）
 ```bash
 npm ci
-cp .env.example .env && edit .env
+cp .env.example .env
+# .env を編集して SEPOLIA_RPC_URL / PRIVATE_KEY を設定（APIキーや秘密鍵はコミットしない）
 npm test
 ```
 


### PR DESCRIPTION
## 変更内容
- Top: Quick Start の `edit .env`（環境依存）を廃止し、コピペで詰まりにくい手順に修正
- Curriculum: プレースホルダ表記（`<...>` と `YOUR_...`）の説明を現状の教材に合わせて更新
- Day7: `scripts/deploy-generic.ts` の説明/例が実装と不一致（Lock 前提）だったため、Hello（デフォルト）前提に統一し、Verify例/最小コマンドも修正
- Day8: `CONTRACT=Lock ...` が本リポジトリでは成立しないため、デフォルトのデプロイコマンドに修正

## 確認
- `npm run check:all`
- Book QA 相当（pinned book-formatter）: unicode / textlint / links / layout-risk / markdown-structure
}