### PR TITLE
docs,tools: pin nvm installer and align Day08 env/verify docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,3 +17,4 @@
 - Issue #93 対応：教材の正誤・不整合を修正（Day1/2 の記録先統一、Day1 のコマンドと出力例の整合、Day3 の導線整理、Day12 のツール説明の誤解低減 など）
 - Issue #96 対応：GitHub Pages での Markdown テーブル崩れを修正し、インラインコード末尾空白を除去（再発防止チェックを CI に追加）
 - Issue #100 対応：Day03 の nvm 初期化コマンド誤記（`\\.` → `\.`）を修正し、nvm の動作確認コマンドを追記
+- Issue #106 対応：Day03 の nvm install URL を release tag 固定に変更し、Day08 の Optimism Verify に必要な env 記載と Markdown style check の対象/ルールを補強

--- a/docs/curriculum/Day03_Env_Setup.md
+++ b/docs/curriculum/Day03_Env_Setup.md
@@ -110,7 +110,8 @@ MTK: 0x...
 ```bash
 sudo apt update && sudo apt install -y git curl ca-certificates
 # 注意：curl | bash の実行前に、公式スクリプト（install.sh）の内容を確認する
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
+# タグは upstream README / release に合わせて更新する
 
 # 以降はシェルを再起動するか、次を実行
 export NVM_DIR="$HOME/.nvm"

--- a/docs/curriculum/Day08_L2_Rollups.md
+++ b/docs/curriculum/Day08_L2_Rollups.md
@@ -78,7 +78,8 @@ L2手数料 ≒ L2実行コスト + L1データ可用性（Blob）コスト
 
 ### 2.1 HardhatにL2を追加（参考）
 このリポジトリでは `sepolia` / `optimism` / `polygonZk` のネットワーク設定は同梱済みだ（`hardhat.config.ts` を確認する）。  
-自分のプロジェクトに追加する場合は、次を参考にする。
+自分のプロジェクトに追加する場合は、次を参考にする。  
+環境変数は **ルートの `.env.example` をベースに管理**し、この章で最低限必要なのは `OPTIMISM_RPC_URL` / `PRIVATE_KEY` / `OPTIMISTIC_ETHERSCAN_API_KEY` だ。
 
 `hardhat.config.ts`
 ```ts
@@ -89,9 +90,13 @@ networks: {
   // polygonZk: { url: process.env.POLYGON_ZKEVM_RPC_URL!, accounts: [process.env.PRIVATE_KEY!] },
 }
 ```
-`.env.example`
+`.env.example`（Day8で最低限見る項目）
 ```bash
 OPTIMISM_RPC_URL=
+PRIVATE_KEY=0xYOUR_PRIVATE_KEY
+OPTIMISTIC_ETHERSCAN_API_KEY=YOUR_OPTIMISTIC_ETHERSCAN_API_KEY
+
+# 任意：Polygon zkEVM も試す場合
 POLYGON_ZKEVM_RPC_URL=
 ```
 

--- a/tools/check-md-style.mjs
+++ b/tools/check-md-style.mjs
@@ -7,6 +7,7 @@ function listTargetMarkdownFiles() {
   const out = execSync(
     [
       'git ls-files --',
+      '"docs/*.md"',
       '"docs/curriculum/*.md"',
       '"docs/reports/*.md"',
       '"docs/appendix/*.md"',
@@ -52,6 +53,10 @@ function isBadNvmInitLine(line) {
   return line.includes('nvm.sh') && line.includes('&&') && line.includes('\\\\.');
 }
 
+function hasUnpinnedNvmInstallerUrl(line) {
+  return line.includes('raw.githubusercontent.com/nvm-sh/nvm/master/install.sh');
+}
+
 function formatProblem({ file, line, message }) {
   return `${file}:${line}: ${message}`;
 }
@@ -72,6 +77,16 @@ for (const file of markdownFiles) {
       inCodeBlock = !inCodeBlock;
       continue;
     }
+
+    if (hasUnpinnedNvmInstallerUrl(line)) {
+      problems.push({
+        file,
+        line: i + 1,
+        message:
+          'contains unpinned nvm installer URL (`master/install.sh`); use a release-tagged URL instead',
+      });
+    }
+
     if (inCodeBlock) {
       // Some bash typos live inside code fences and won't be caught by prose/table rules.
       if (isBadNvmInitLine(line)) {


### PR DESCRIPTION
Closes #106

## 変更内容
- Day03: `nvm` install URL を `master/install.sh` から release-tagged URL（`v0.40.4`）に固定し、upstream README / release に合わせてタグ更新する旨を追記
- Day08: `.env.example` の抜粋を見直し、Optimism Verify に必要な `OPTIMISTIC_ETHERSCAN_API_KEY` と `PRIVATE_KEY` がこの章だけで分かるように補足
- `tools/check-md-style.mjs`: 走査対象を `docs/*.md` まで拡張し、`raw.githubusercontent.com/nvm-sh/nvm/master/install.sh` のような unpinned installer URL を検出して fail
- Changelog: 2026.02 に Issue #106 の履歴を追記

## 確認
- `npm run check:md-style`
- `master/install.sh` を一時的に戻すと `check:md-style` が fail することを手元で確認
- `npm run check:all`
- Book QA 相当（pinned book-formatter）: unicode / textlint / links / layout-risk / markdown-structure

## 根拠
- nvm 最新 release: `v0.40.4`（GitHub release, 2026-01-29 時点）
