### PR TITLE
[codex] Add ethereum bootcamp metadata QA gate

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -38,6 +38,9 @@ jobs:
         working-directory: book-formatter
         run: npm ci
 
+      - name: Check book metadata
+        run: node tools/check-metadata.mjs
+
       - name: Determine scan directory
         id: scan
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npm run check:metadata
       - run: npm test
       - run: npm run check:links
       - run: npm run check:md-style

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ cp .env.example .env
 
 （まとめて確認する場合：`npm run check:all`）
 
+### メタデータ整合性チェック
+
+```bash
+npm run check:metadata
+```
+
+`npm run check:metadata` は、`book-config.json` / `package.json` / `package-lock.json` / `docs/_config.yml` / `docs/index.md` のタイトル・説明・著者・版数・公開URLがずれていないことを検証します。
+
 ## 安全運用の注意
 - 学習用の秘密鍵とテストネットを使い、Mainnet や実資産を扱う鍵は使わないでください。
 - `.env` / `.env.local` はコミットせず、ログや画面共有にも秘密情報を残さないでください。

--- a/book-config.json
+++ b/book-config.json
@@ -2,7 +2,7 @@
   "title": "Ethereum Learning Bootcamp",
   "description": "14日間でEthereum開発の基礎から応用まで学ぶ完全教材",
   "author": "ITDO Inc.",
-  "version": "2026.01",
+  "version": "2026.05",
   "language": "ja",
   "license": "CC-BY-NC-SA-4.0",
   "repository": {

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 layout: book
 title: "Ethereum Learning Bootcamp"
 description: "14日間でEthereum開発の基礎から応用まで学ぶ完全教材"
+author: "ITDO Inc."
+version: "2026.05"
 permalink: /
 ---
 

--- a/package.json
+++ b/package.json
@@ -2,17 +2,28 @@
   "name": "ethereum-learning-bootcamp",
   "private": true,
   "version": "0.1.0",
+  "description": "14日間でEthereum開発の基礎から応用まで学ぶ完全教材",
+  "author": "ITDO Inc.",
   "license": "CC-BY-NC-SA-4.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/itdojp/ethereum-learning-bootcamp.git"
+  },
+  "homepage": "https://itdojp.github.io/ethereum-learning-bootcamp/",
+  "bugs": {
+    "url": "https://github.com/itdojp/ethereum-learning-bootcamp/issues"
+  },
   "scripts": {
     "build": "hardhat compile",
     "test": "hardhat test",
     "coverage": "hardhat coverage",
     "check:links": "node tools/check-links.mjs",
     "check:md-style": "node tools/check-md-style.mjs",
-    "check:all": "npm test && npm run check:links && npm run check:md-style && npm --prefix dapp ci && npm --prefix dapp run build",
+    "check:all": "npm run check:metadata && npm test && npm run check:links && npm run check:md-style && npm --prefix dapp ci && npm --prefix dapp run build",
     "dapp:build": "npm --prefix dapp run build",
     "lint": "echo 'add linter if needed'",
-    "deploy:sepolia": "hardhat run scripts/deploy-generic.ts --network sepolia"
+    "deploy:sepolia": "hardhat run scripts/deploy-generic.ts --network sepolia",
+    "check:metadata": "node tools/check-metadata.mjs"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^6.1.0",

--- a/tools/check-metadata.mjs
+++ b/tools/check-metadata.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const errors = [];
+
+function readText(file) {
+  return fs.readFileSync(path.join(root, file), 'utf8');
+}
+
+function readJson(file) {
+  return JSON.parse(readText(file));
+}
+
+function unquote(value) {
+  const trimmed = String(value ?? '').trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseYamlScalars(text) {
+  const values = {};
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.trim() || line.trimStart().startsWith('#')) continue;
+    const match = line.match(/^([A-Za-z0-9_.-]+):\s*(.*)$/);
+    if (!match) continue;
+    values[match[1]] = unquote(match[2]);
+  }
+  return values;
+}
+
+function parseFrontMatter(file) {
+  const text = readText(file);
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!match) {
+    errors.push(`${file}: front matter is missing`);
+    return {};
+  }
+  return parseYamlScalars(match[1]);
+}
+
+function parseGitHubRepositoryUrl(value, label) {
+  if (typeof value !== 'string' || !value.trim()) {
+    errors.push(`${label}: expected a non-empty GitHub repository URL`);
+    return null;
+  }
+
+  try {
+    const parsed = new URL(value.trim().replace(/\.git$/, ''));
+    const [owner, repo, ...rest] = parsed.pathname.replace(/^\//, '').split('/');
+    if (parsed.hostname !== 'github.com' || !owner || !repo || rest.length) {
+      errors.push(`${label}: expected https://github.com/<owner>/<repo>[.git], got ${JSON.stringify(value)}`);
+      return null;
+    }
+    return {
+      owner,
+      repo,
+      slug: `${owner}/${repo}`,
+      url: `https://github.com/${owner}/${repo}`,
+      gitUrl: `https://github.com/${owner}/${repo}.git`,
+    };
+  } catch (error) {
+    errors.push(`${label}: expected a valid URL, got ${JSON.stringify(value)} (${error.message})`);
+    return null;
+  }
+}
+
+function expectEqual(label, actual, expected) {
+  if (actual !== expected) {
+    errors.push(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function expectTruthy(label, actual) {
+  if (!actual) {
+    errors.push(`${label}: expected a non-empty value`);
+  }
+}
+
+const bookConfig = readJson('book-config.json');
+const pkg = readJson('package.json');
+const lock = readJson('package-lock.json');
+const docsConfig = parseYamlScalars(readText('docs/_config.yml'));
+const docsIndex = parseFrontMatter('docs/index.md');
+const repository = parseGitHubRepositoryUrl(bookConfig.repository && bookConfig.repository.url, 'book-config.json repository.url');
+
+const owner = repository ? repository.owner : 'itdojp';
+const repo = repository ? repository.repo : 'ethereum-learning-bootcamp';
+const repoSlug = `${owner}/${repo}`;
+const repoUrl = `https://github.com/${repoSlug}`;
+const repoGitUrl = `${repoUrl}.git`;
+const pagesBaseUrl = `https://${owner}.github.io`;
+const pagesUrl = `${pagesBaseUrl}/${repo}/`;
+const issuesUrl = `${repoUrl}/issues`;
+
+expectEqual('book-config.json title', bookConfig.title, 'Ethereum Learning Bootcamp');
+expectTruthy('book-config.json description', bookConfig.description);
+expectEqual('book-config.json language', bookConfig.language, 'ja');
+expectEqual('book-config.json license', bookConfig.license, 'CC-BY-NC-SA-4.0');
+expectEqual('book-config.json repository.branch', bookConfig.repository && bookConfig.repository.branch, 'main');
+
+expectEqual('package.json name', pkg.name, repo);
+expectEqual('package.json description', pkg.description, bookConfig.description);
+expectEqual('package.json author', pkg.author, bookConfig.author);
+expectEqual('package.json license', pkg.license, bookConfig.license);
+expectEqual('package.json repository.url', pkg.repository && pkg.repository.url, repoGitUrl);
+expectEqual('package.json homepage', pkg.homepage, pagesUrl);
+expectEqual('package.json bugs.url', pkg.bugs && pkg.bugs.url, issuesUrl);
+expectEqual('package.json scripts.check:metadata', pkg.scripts && pkg.scripts['check:metadata'], 'node tools/check-metadata.mjs');
+
+expectEqual('package-lock.json name', lock.name, repo);
+expectEqual('package-lock.json packages[""].name', lock.packages && lock.packages[''] && lock.packages[''].name, repo);
+expectEqual('package-lock.json packages[""].license', lock.packages && lock.packages[''] && lock.packages[''].license, bookConfig.license);
+
+expectEqual('docs/_config.yml title', docsConfig.title, bookConfig.title);
+expectEqual('docs/_config.yml description', docsConfig.description, bookConfig.description);
+expectEqual('docs/_config.yml author', docsConfig.author, bookConfig.author);
+expectEqual('docs/_config.yml version', docsConfig.version, bookConfig.version);
+expectEqual('docs/_config.yml lang', docsConfig.lang, bookConfig.language);
+expectEqual('docs/_config.yml url', docsConfig.url, pagesBaseUrl);
+expectEqual('docs/_config.yml baseurl', docsConfig.baseurl, `/${repo}`);
+expectEqual('docs/_config.yml repository', docsConfig.repository, repoSlug);
+
+expectEqual('docs/index.md front matter title', docsIndex.title, bookConfig.title);
+expectEqual('docs/index.md front matter description', docsIndex.description, bookConfig.description);
+expectEqual('docs/index.md front matter author', docsIndex.author, bookConfig.author);
+expectEqual('docs/index.md front matter version', docsIndex.version, bookConfig.version);
+
+if (errors.length) {
+  console.error('Metadata consistency check failed:');
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+console.log('Metadata consistency check passed.');
+console.log(`Repository: ${repoSlug}`);
+console.log(`Book version: ${bookConfig.version}`);
+console.log(`Pages: ${pagesUrl}`);

--- a/tools/check-metadata.mjs
+++ b/tools/check-metadata.mjs
@@ -37,7 +37,7 @@ function parseYamlScalars(text) {
 
 function parseFrontMatter(file) {
   const text = readText(file);
-  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
   if (!match) {
     errors.push(`${file}: front matter is missing`);
     return {};
@@ -53,7 +53,12 @@ function parseGitHubRepositoryUrl(value, label) {
 
   try {
     const parsed = new URL(value.trim().replace(/\.git$/, ''));
-    const [owner, repo, ...rest] = parsed.pathname.replace(/^\//, '').split('/');
+    const segments = parsed.pathname
+      .replace(/\/+$/, '')
+      .replace(/^\//, '')
+      .split('/')
+      .filter(Boolean);
+    const [owner, repo, ...rest] = segments;
     if (parsed.hostname !== 'github.com' || !owner || !repo || rest.length) {
       errors.push(`${label}: expected https://github.com/<owner>/<repo>[.git], got ${JSON.stringify(value)}`);
       return null;


### PR DESCRIPTION
## Summary
- add `tools/check-metadata.mjs` to validate repository, package, Pages, Jekyll, and top-page metadata consistency
- align `book-config.json` book version with the published `docs/_config.yml` version (`2026.05`) and add `docs/index.md` author/version front matter
- add package repository-facing metadata (`description`, `author`, `repository`, `homepage`, `bugs`) and wire `check:metadata` into local/CI QA

## Validation
- [x] `npm ci` (existing dev audit findings reported by npm; production/non-optional audit is clean)
- [x] `npm run check:metadata`
- [x] `npm test`
- [x] `npm run check:links`
- [x] `npm run check:md-style`
- [x] `npm --prefix dapp ci`
- [x] `npm --prefix dapp run build`
- [x] `npm audit --omit=dev --omit=optional`
- [x] `npm --prefix dapp audit --omit=dev --omit=optional`
- [x] positive metadata fixtures for trailing-slash GitHub URL and EOF-after-front-matter closing marker
- [x] negative metadata fixture for missing `package.json.repository` returns validation errors without uncaught TypeError
- [x] `git diff --check`
- [x] CI-pinned book-formatter checks: unicode, textlint/PRH, internal links/anchors, layout risk, markdown structure

## Review / release gates
- [x] GitHub Copilot review checked; all comments/suggestions handled or explicitly replied
- [x] CI green on PR head
- [x] Merge to `main`
- [x] Public GitHub Pages smoke passed after merge

Part of itdojp/it-engineer-knowledge-architecture#152.